### PR TITLE
Export log file per activation reference

### DIFF
--- a/src/plugins/pota/POTAActivity.jsx
+++ b/src/plugins/pota/POTAActivity.jsx
@@ -1,5 +1,6 @@
 import { apiPOTA } from '../../store/apiPOTA'
 import { findRef, refsToString } from '../../tools/refTools'
+import { adifField } from '../../tools/qsonToADIF'
 
 import { POTAActivityOptions } from './POTAActivityOptions'
 import { POTALoggingControl } from './POTALoggingControl'
@@ -102,6 +103,14 @@ const POTAActivity = {
     } else {
       return null
     }
+  },
+
+  activationADIF: (activationRef) => {
+    return adifField('MY_SIG', 'POTA') + adifField('MY_SIG_INFO', activationRef.ref) + adifField('MY_POTA_REF', activationRef.ref)
+  },
+
+  huntingADIF: (huntingRef) => {
+    return adifField('SIG', 'POTA') + adifField('SIG_INFO', huntingRef.ref) + adifField('POTA_REF', huntingRef.ref)
   }
 
 }

--- a/src/plugins/sota/SOTAActivity.jsx
+++ b/src/plugins/sota/SOTAActivity.jsx
@@ -1,4 +1,5 @@
 import { findRef, refsToString } from '../../tools/refTools'
+import { adifField } from '../../tools/qsonToADIF'
 
 import { INFO } from './SOTAInfo'
 import { SOTAActivityOptions } from './SOTAActivityOptions'
@@ -77,7 +78,16 @@ const SOTAActivity = {
     } else {
       return null
     }
+  },
+
+  activationADIF: (activationRef) => {
+    return adifField('MY_SOTA_REF', activationRef.ref)
+  },
+
+  huntingADIF: (huntingRef) => {
+    return adifField('SOTA_REF', huntingRef.ref)
   }
+
 }
 
 export default SOTAActivity

--- a/src/plugins/wwff/WWFFActivity.jsx
+++ b/src/plugins/wwff/WWFFActivity.jsx
@@ -1,4 +1,5 @@
 import { findRef, refsToString } from '../../tools/refTools'
+import { adifField } from '../../tools/qsonToADIF'
 
 import { INFO } from './WWFFInfo'
 import { WWFFActivityOptions } from './WWFFActivityOptions'
@@ -77,6 +78,14 @@ const WWFFActivity = {
     } else {
       return null
     }
+  },
+
+  activationADIF: (activationRef) => {
+    return adifField('MY_SIG', 'WWFF') + adifField('MY_SIG_INFO', activationRef.ref)
+  },
+
+  huntingADIF: (huntingRef) => {
+    return adifField('SIG', 'WWFF') + adifField('SIG_INFO', huntingRef.ref)
   }
 }
 


### PR DESCRIPTION
This also moves logic for ADIF generation to plugins. Where no activation is taking place, a single log is generate with any hunting references present in that one file.

A QSO line is also generated per hunted reference, which will have no effect on SOTA or WWFF as they are single activation only.