### PR TITLE
Add a Custom Activity extension

### DIFF
--- a/src/extensions/activities/custom/CustomActivityOptions.jsx
+++ b/src/extensions/activities/custom/CustomActivityOptions.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useMemo, useCallback } from 'react'
+import { useDispatch } from 'react-redux'
+import { Button, List, TextInput } from 'react-native-paper'
+
+import { setOperationData } from '../../../store/operations'
+import { filterRefs, replaceRefs } from '../../../tools/refTools'
+import { Info } from './CustomInfo'
+import { CustomListItem } from './CustomListItem'
+import { ListRow } from '../../../screens/components/ListComponents'
+
+export function CustomActivityOptions (props) {
+  const { styles, operation } = props
+
+  const dispatch = useDispatch()
+
+  const [mySig, setMySig] = useState('')
+  const [mySigInfo, setMySigInfo] = useState('')
+  const [name, setName] = useState('')
+  const refs = useMemo(() => filterRefs(operation, Info.activationType), [operation]).filter(ref => ref.ref)
+
+  const title = useMemo(() => {
+    if (refs?.length === 0) return 'No references provided for activation'
+    else return 'Activating references:'
+  }, [refs])
+
+  const handleAddReference = useCallback((refMySigInfo, refName, refMySig) => {
+    const data = {
+      type: Info.activationType,
+      ref: [refMySig.trim(), refMySigInfo.trim()].filter(x => x).join(' '),
+      name: refName,
+      mySig: refMySig,
+      mySigInfo: refMySigInfo
+    }
+    if (data.ref !== '') dispatch(setOperationData({ uuid: operation.uuid, refs: replaceRefs(operation?.refs, Info.activationType, [...refs.filter(r => r.ref !== data.ref), data]) }))
+  }, [dispatch, operation, refs])
+
+  const handleRemoveReference = useCallback((ref) => {
+    dispatch(setOperationData({ uuid: operation.uuid, refs: replaceRefs(operation?.refs, Info.activationType, refs.filter(r => r.ref !== ref)) }))
+  }, [dispatch, operation, refs])
+
+  return (
+    <>
+      <List.Section title={title}>
+        {refs.map((ref, index) => (
+          <CustomListItem
+            key={ref.ref}
+            activityRef={ref}
+            styles={styles}
+            onRemoveReference={handleRemoveReference}
+          />
+        ))}
+      </List.Section>
+      <List.Section title={refs?.length === 0 ? 'Add more references' : 'Add a reference'}>
+        <ListRow style={{ paddingBottom: styles.oneSpace * 1 }}>
+          <TextInput
+            label="Activity - MY_SIG in ADIF (Optional)"
+            placeholder={'COTA…'}
+            value={mySig}
+            onChangeText={text => setMySig(text)}
+          />
+        </ListRow>
+        <ListRow style={{ paddingBottom: styles.oneSpace * 1 }}>
+          <TextInput
+            label="Reference - MY_SIG_INFO in ADIF"
+            placeholder={'XY-1234…'}
+            value={mySigInfo}
+            onChangeText={text => setMySigInfo(text)}
+          />
+        </ListRow>
+        <ListRow style={{ paddingBottom: styles.oneSpace * 1 }}>
+          <TextInput
+            label="Name (Optional)"
+            placeholder={'XYZ Castle…'}
+            value={name}
+            onChangeText={text => setName(text)}
+          />
+        </ListRow>
+        <ListRow>
+          <Button icon="plus-circle" mode="contained" onPress = {() => handleAddReference(mySigInfo, name, mySig) }>Add</Button>
+        </ListRow>
+      </List.Section>
+    </>
+  )
+}

--- a/src/extensions/activities/custom/CustomExtension.js
+++ b/src/extensions/activities/custom/CustomExtension.js
@@ -1,0 +1,106 @@
+import { filterRefs, findRef, refsToString } from '../../../tools/refTools'
+
+import { Info } from './CustomInfo'
+import { CustomActivityOptions } from './CustomActivityOptions'
+import { CustomLoggingControl } from './CustomLoggingControl'
+
+const Extension = {
+  ...Info,
+  category: 'locationBased',
+  onActivationDispatch: ({ registerHook }) => async (dispatch) => {
+    registerHook('activity', { hook: ActivityHook })
+    registerHook(`ref:${Info.huntingType}`, { hook: ReferenceHandler })
+    registerHook(`ref:${Info.activationType}`, { hook: ReferenceHandler })
+  }
+}
+export default Extension
+
+const ActivatorLoggingControl = {
+  key: 'custom/activator',
+  order: 10,
+  icon: Info.icon,
+  label: ({ operation, qso }) => {
+    const parts = ['Custom']
+    if (findRef(qso, Info.huntingType)) parts.unshift('✓')
+    return parts.join(' ')
+  },
+  InputComponent: CustomLoggingControl,
+  optionType: 'optional'
+}
+
+const ActivityHook = {
+  ...Info,
+  MainExchangePanel: null,
+  loggingControls: ({ operation, settings }) => {
+    if (findRef(operation, Info.activationType)) {
+      return [ActivatorLoggingControl]
+    } else {
+      return []
+    }
+  },
+  Options: CustomActivityOptions,
+
+  includeControlForQSO: ({ qso, operation }) => {
+    if (findRef(operation, Info.activationType)) return true
+    if (findRef(qso, Info.huntingType)) return true
+    else return false
+  },
+
+  labelControlForQSO: ({ operation, qso }) => {
+    let label = 'Custom'
+    if (findRef(qso, Info.huntingType)) label = `✓ ${label}`
+    return label
+  }
+}
+
+const ReferenceHandler = {
+  ...Info,
+
+  description: (operation) => refsToString(operation, Info.activationType),
+
+  decorateRef: (ref) => {
+    return ref // Custom so no known extra data
+  },
+
+  suggestOperationTitle: (ref) => {
+    if (ref.type === Info.activationType && ref.ref) {
+      return {
+        at: ref.ref,
+        subtitle: ref.name
+      }
+    } else {
+      return null
+    }
+  },
+
+  suggestExportOptions: ({ operation, ref, settings }) => {
+    if (ref.type === Info.activationType && ref.ref) {
+      return [{
+        format: 'adif',
+        common: { refs: [ref] },
+        nameTemplate: settings.useCompactFileNames ? '{call}@{ref}-{compactDate}' : '{date} {call} at {ref}',
+        titleTemplate: `{call}: ${Info.shortName} at ${[ref.ref, ref.name].filter(x => x).join(' - ')} on {date}`
+      }]
+    }
+  },
+
+  adifFieldCombinationsForOneQSO: ({ qso, operation, common }) => {
+    const huntingRefs = filterRefs(qso, Info.huntingType)
+    const activationRef = findRef(operation, Info.activationType)
+    const activationADIF = []
+    if (activationRef) {
+      if (activationRef?.mySig) activationADIF.push({ MY_SIG: activationRef.mySig })
+      if (activationRef?.mySigInfo) activationADIF.push({ MY_SIG_INFO: activationRef.mySigInfo })
+    }
+
+    if (huntingRefs.length > 0) {
+      if (activationRef?.mySig) activationADIF.push({ SIG: activationRef.mySig })
+      return huntingRefs.map(huntingRef => [
+        ...activationADIF,
+        { SIG_INFO: huntingRef.ref }
+      ])
+    } else {
+      return [activationADIF]
+    }
+  }
+}

--- a/src/extensions/activities/custom/CustomInfo.js
+++ b/src/extensions/activities/custom/CustomInfo.js
@@ -1,0 +1,11 @@
+export const Info = {
+  key: 'custom',
+  icon: 'radio-handheld',
+  name: 'Custom Activity',
+  shortName: 'Custom',
+  infoURL: '',
+  huntingType: 'custom',
+  activationType: 'customActivation',
+  descriptionPlaceholder: 'Enter reference',
+  referenceRegex: /./
+}

--- a/src/extensions/activities/custom/CustomInput.jsx
+++ b/src/extensions/activities/custom/CustomInput.jsx
@@ -1,0 +1,27 @@
+import React, { useCallback } from 'react'
+import { useThemedStyles } from '../../../styles/tools/useThemedStyles'
+import ThemedTextInput from '../../../screens/components/ThemedTextInput'
+
+export default function CustomInput (props) {
+  const { textStyle, onChange, onChangeText, fieldId } = props
+
+  const styles = useThemedStyles()
+
+  const handleChange = useCallback((event) => {
+    const { text } = event.nativeEvent
+    onChangeText && onChangeText(text)
+    onChange && onChange({ ...event, fieldId })
+  }, [onChange, onChangeText, fieldId])
+
+  return (
+    <ThemedTextInput
+      {...props}
+      keyboard="dumb"
+      uppercase={false}
+      nospaces={false}
+      placeholder={'ref…'}
+      textStyle={[textStyle, styles?.text?.callsign]}
+      onChange={handleChange}
+    />
+  )
+}

--- a/src/extensions/activities/custom/CustomListItem.jsx
+++ b/src/extensions/activities/custom/CustomListItem.jsx
@@ -1,0 +1,25 @@
+/* eslint-disable react/no-unstable-nested-components */
+import React from 'react'
+import { IconButton, List, Text } from 'react-native-paper'
+import { View } from 'react-native'
+
+import { Info } from './CustomInfo'
+
+export function CustomListItem ({ activityRef, style, styles, onPress, onRemoveReference }) {
+  return (
+    <List.Item style={{ paddingRight: styles.oneSpace * 1 }}
+      title={
+        <View style={{ flexDirection: 'row' }}>
+          <Text style={{ fontWeight: 'bold' }}>
+            {[activityRef?.mySig, activityRef?.mySigInfo].filter(x => x).join(' ')}
+          </Text>
+        </View>
+      }
+      description={activityRef?.name}
+      onPress={onPress}
+      left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon={Info.icon} />}
+      right={() => (onRemoveReference && <IconButton icon="minus-circle-outline" onPress={() => onRemoveReference(activityRef.ref)} />
+      )}
+    />
+  )
+}

--- a/src/extensions/activities/custom/CustomLoggingControl.jsx
+++ b/src/extensions/activities/custom/CustomLoggingControl.jsx
@@ -1,0 +1,44 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+import { filterRefs, refsToString, replaceRefs, stringToRefs } from '../../../tools/refTools'
+import { Info } from './CustomInfo'
+import CustomInput from './CustomInput'
+
+export function CustomLoggingControl (props) {
+  const { qso, setQSO, style, styles } = props
+
+  const ref = useRef()
+  useEffect(() => {
+    setTimeout(() => {
+      ref?.current?.focus()
+    }, 0)
+  }, [ref])
+
+  const [localValue, setLocalValue] = useState('')
+
+  // Only initialize localValue once
+  useEffect(() => {
+    const refs = filterRefs(qso, Info.huntingType)
+    if (!localValue) {
+      setLocalValue(refsToString(refs, Info.huntingType))
+    }
+  }, [qso, localValue])
+
+  const localHandleChangeText = useCallback((value) => {
+    setLocalValue(value)
+    const refs = stringToRefs(Info.huntingType, value, { regex: Info.referenceRegex })
+
+    setQSO({ ...qso, refs: replaceRefs(qso?.refs, Info.huntingType, refs) })
+  }, [qso, setQSO])
+
+  return (
+    <CustomInput
+      {...props}
+      innerRef={ref}
+      style={[style, { minWidth: 16 * styles.oneSpace }]}
+      value={localValue}
+      label="Their Ref"
+      onChangeText={localHandleChangeText}
+    />
+  )
+}

--- a/src/extensions/loadExtensions.js
+++ b/src/extensions/loadExtensions.js
@@ -7,6 +7,7 @@ import SOTAExtension from './activities/sota/SOTAExtension'
 import WWFFExtension from './activities/wwff/WWFFExtension'
 import FDExtension from './activities/fd/FDExtension'
 import WFDExtension from './activities/wfd/WFDExtension'
+import CustomExtension from './activities/custom/CustomExtension'
 
 import RadioCommands from './commands/RadioCommands'
 import DevModeCommands from './commands/DevModeCommands'
@@ -17,6 +18,7 @@ const loadExtensions = () => (dispatch, getState) => {
   registerExtension(POTAExtension)
   registerExtension(SOTAExtension)
   registerExtension(WWFFExtension)
+  registerExtension(CustomExtension)
   registerExtension(WFDExtension)
   registerExtension(FDExtension)
 

--- a/src/screens/OperationScreens/OpLoggingTab/components/QSOItem.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/QSOItem.jsx
@@ -17,7 +17,8 @@ export function guessItemHeight (qso, styles) {
 const REFS_TO_INCLUDE = {
   pota: true,
   sota: true,
-  wwff: true
+  wwff: true,
+  custom: true
 }
 
 const QSOItem = React.memo(function QSOItem ({ qso, ourInfo, onPress, styles, selected, extendedWidth, settings }) {


### PR DESCRIPTION
This allows setting of one or more custom MY_SIG/MY_SIG_INFO fields for ADIF export, along with optional name for display and ADIF header. Also allows P2P like entry, similar to POTA allowing multiple P2Ps per QSO, producing ADIF QSO line per reference.