### PR TITLE
Add support for WAB Square in Operation Info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "deepmerge": "^4.3.1",
         "fast-xml-parser": "^4.3.2",
         "fuzzball": "^2.1.2",
+        "proj4": "^2.11.0",
         "react": "18.2.0",
         "react-native": "0.72.6",
         "react-native-blob-util": "^0.19.6",
@@ -15181,6 +15182,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -17242,6 +17248,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "node_modules/proj4": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.11.0.tgz",
+      "integrity": "sha512-SasuTkAx8HnWQHfIyhkdUNJorSJqINHAN3EyMWYiQRVorftz9DHz650YraFgczwgtHOxqnfuDxSNv3C8MUnHeg==",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.3"
+      }
     },
     "node_modules/promise": {
       "version": "8.3.0",
@@ -20712,6 +20727,11 @@
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
+    },
+    "node_modules/wkt-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
+      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "deepmerge": "^4.3.1",
     "fast-xml-parser": "^4.3.2",
     "fuzzball": "^2.1.2",
+    "proj4": "^2.11.0",
     "react": "18.2.0",
     "react-native": "0.72.6",
     "react-native-blob-util": "^0.19.6",

--- a/src/extensions/loadExtensions.js
+++ b/src/extensions/loadExtensions.js
@@ -22,6 +22,8 @@ import TimeCommands from './commands/TimeCommands'
 import DevModeCommands from './commands/DevModeCommands'
 import CallNotesExtension from './data/call-notes/CallNotesExtension'
 
+import WABExtension from './other/wab/WABExtension'
+
 const loadExtensions = () => async (dispatch, getState) => {
   dispatch(addRuntimeMessage('Loading extensions'))
   registerExtension(CountryFilesExtension)
@@ -38,6 +40,8 @@ const loadExtensions = () => async (dispatch, getState) => {
   registerExtension(DevModeCommands)
 
   registerExtension(CallNotesExtension)
+
+  registerExtension(WABExtension)
 
   await activateEnabledExtensions(dispatch, getState)
 }

--- a/src/extensions/other/wab/WABExtension.js
+++ b/src/extensions/other/wab/WABExtension.js
@@ -3,7 +3,7 @@ import { WABOpSetting } from './components/WABOpSetting'
 export const Info = {
   key: 'wab-square',
   name: 'Worked All Britain (WAB)',
-  icon: 'map-marker-path',
+  icon: 'selection-marker',
   description: 'Add WAB Square to operation'
 }
 

--- a/src/extensions/other/wab/WABExtension.js
+++ b/src/extensions/other/wab/WABExtension.js
@@ -1,3 +1,10 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 import { WABOpSetting } from './components/WABOpSetting'
 
 export const Info = {

--- a/src/extensions/other/wab/WABExtension.js
+++ b/src/extensions/other/wab/WABExtension.js
@@ -1,0 +1,24 @@
+import { WABOpSetting } from './components/WABOpSetting'
+
+export const Info = {
+  key: 'wab-square',
+  name: 'Worked All Britain (WAB)',
+  icon: 'map-marker-path',
+  description: 'Add WAB Square to operation'
+}
+
+const Extension = {
+  ...Info,
+  category: 'other',
+  onActivationDispatch: ({ registerHook }) => async (dispatch) => {
+    registerHook('opSetting', {
+      hook: {
+        key: 'wab-square-selector',
+        category: 'detail',
+        OpSettingItem: WABOpSetting
+      }
+    })
+  }
+}
+
+export default Extension

--- a/src/extensions/other/wab/WABLocation.js
+++ b/src/extensions/other/wab/WABLocation.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 import proj4 from 'proj4/dist/proj4-src.js'
 
 proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 +units=m +no_defs')

--- a/src/extensions/other/wab/WABLocation.js
+++ b/src/extensions/other/wab/WABLocation.js
@@ -1,0 +1,65 @@
+import proj4 from 'proj4/dist/proj4-src.js'
+
+proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 +units=m +no_defs')
+proj4.defs('EPSG:29903', '+proj=tmerc +lat_0=53.5 +lon_0=-8 +k=1.000035 +x_0=200000 +y_0=250000 +a=6377340.189 +rf=299.3249646 +towgs84=482.5,-130.6,564.6,-1.042,-0.214,-0.631,8.15 +units=m +no_defs +type=crs')
+proj4.defs('EPSG:32630', '+proj=utm +zone=30 +datum=WGS84 +units=m +no_defs +type=crs')
+
+const osGridPrefixes = [
+  ['SV', 'SW', 'SX', 'SY', 'SZ', 'TV', 'TW'],
+  ['SQ', 'SR', 'SS', 'ST', 'SU', 'TQ', 'TR'],
+  ['SL', 'SM', 'SN', 'SO', 'SP', 'TL', 'TM'],
+  ['SF', 'SG', 'SH', 'SJ', 'SK', 'TF', 'TG'],
+  ['SA', 'SB', 'SC', 'SD', 'SE', 'TA', 'TB'],
+  ['NV', 'NW', 'NX', 'NY', 'NZ', 'OV', 'OW'],
+  ['NQ', 'NR', 'NS', 'NT', 'NU', 'OQ', 'OR'],
+  ['NL', 'NM', 'NN', 'NO', 'NP', 'OL', 'OM'],
+  ['NF', 'NG', 'NH', 'NJ', 'NK', 'OF', 'OG'],
+  ['NA', 'NB', 'NC', 'ND', 'NE', 'OA', 'OB'],
+  ['HV', 'HW', 'HX', 'HY', 'HZ', 'JV', 'JW'],
+  ['HQ', 'HR', 'HS', 'HT', 'HU', 'JQ', 'JR'],
+  ['HL', 'HM', 'HN', 'HO', 'HP', 'JL', 'JM']
+]
+
+const CI_BBOX = [-2.988281, 48.980217, -1.625977, 49.759978]
+const NI_BBOX = [-8.187561, 53.977090, -5.248718, 55.394712]
+
+function OSGBPrefix (e, n) {
+  return osGridPrefixes?.[Math.floor(n / 100000)]?.[Math.floor(e / 100000)]
+}
+
+function IrishPrefix (e, n) {
+  const alphabet = 'ABCDEFGHJKLMNOPQRSTUVWXYZ'
+  return alphabet[20 - Math.floor(n / 100000) * 5 + Math.floor(e / 100000)]
+}
+
+function MGRSPrefix (e, n) {
+  const eAlphabet = 'STUVWXYZ'
+  const nAlphabet = 'ABCDEFGHJKLMNPQRSTUV'
+  const ePrefix = eAlphabet[Math.floor(e / 100000) - 1]
+  const nPrefix = nAlphabet[(Math.floor(n / 100000) + 5) % 20] // zone 'F' start
+  return ePrefix + nPrefix
+}
+
+function WABSquare (lat, lon, prefixFunc, projection) {
+  const [e, n] = proj4('EPSG:4326', projection, [lon, lat])
+  const prefix = prefixFunc(e, n)
+  if (prefix) {
+    return `${prefix}${Math.floor((e % 100000) / 10000)}${Math.floor((n % 100000) / 10000)}`
+  }
+}
+
+export function locationToWABSquare (latitude, longitude) {
+  let prefixFunc = OSGBPrefix
+  let projection = 'EPSG:27700'
+
+  if (longitude > CI_BBOX[0] && longitude < CI_BBOX[2] &&
+      latitude > CI_BBOX[1] && latitude < CI_BBOX[3]) {
+    prefixFunc = MGRSPrefix
+    projection = 'EPSG:32630'
+  } else if (longitude > NI_BBOX[0] && longitude < NI_BBOX[2] &&
+             latitude > NI_BBOX[1] && latitude < NI_BBOX[3]) {
+    prefixFunc = IrishPrefix
+    projection = 'EPSG:29903'
+  }
+  return WABSquare(latitude, longitude, prefixFunc, projection)
+}

--- a/src/extensions/other/wab/components/WABOpSetting.jsx
+++ b/src/extensions/other/wab/components/WABOpSetting.jsx
@@ -6,6 +6,7 @@ import { selectOperationCallInfo } from '../../../../store/operations'
 import { Ham2kListItem } from '../../../../screens/components/Ham2kListItem'
 
 import { WABSquareDialog } from './WABSquareDialog'
+import { Info } from '../WABExtension'
 
 export function WABOpSetting ({ styles, operation, settings }) {
   const [currentDialog, setCurrentDialog] = useState()
@@ -18,7 +19,7 @@ export function WABOpSetting ({ styles, operation, settings }) {
           description={operation?.wabSquare ? `${operation.wabSquare}` : 'No square set'}
           onPress={() => setCurrentDialog('wabSquare')}
           // eslint-disable-next-line react/no-unstable-nested-components
-          left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="map-marker-path" />}
+          left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon={Info.icon} />}
         />
         {currentDialog === 'wabSquare' && (
           <WABSquareDialog

--- a/src/extensions/other/wab/components/WABOpSetting.jsx
+++ b/src/extensions/other/wab/components/WABOpSetting.jsx
@@ -1,3 +1,10 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 import React, { useState } from 'react'
 import { List } from 'react-native-paper'
 import { useSelector } from 'react-redux'

--- a/src/extensions/other/wab/components/WABOpSetting.jsx
+++ b/src/extensions/other/wab/components/WABOpSetting.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react'
+import { List } from 'react-native-paper'
+import { useSelector } from 'react-redux'
+
+import { selectOperationCallInfo } from '../../../../store/operations'
+import { Ham2kListItem } from '../../../../screens/components/Ham2kListItem'
+
+import { WABSquareDialog } from './WABSquareDialog'
+
+export function WABOpSetting ({ styles, operation, settings }) {
+  const [currentDialog, setCurrentDialog] = useState()
+  const callInfo = useSelector(state => selectOperationCallInfo(state, operation?.uuid))
+  if (callInfo?.entityPrefix?.[0] === 'G') {
+    return (
+      <React.Fragment>
+        <Ham2kListItem
+          title="Worked All Britain Square"
+          description={operation?.wabSquare ? `${operation.wabSquare}` : 'No square set'}
+          onPress={() => setCurrentDialog('wabSquare')}
+          // eslint-disable-next-line react/no-unstable-nested-components
+          left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="map-marker-path" />}
+        />
+        {currentDialog === 'wabSquare' && (
+          <WABSquareDialog
+            settings={settings}
+            operation={operation}
+            styles={styles}
+            visible={true}
+            onDialogDone={() => setCurrentDialog('')}
+          />
+        )}
+      </React.Fragment>
+    )
+  }
+}

--- a/src/extensions/other/wab/components/WABSquareDialog.jsx
+++ b/src/extensions/other/wab/components/WABSquareDialog.jsx
@@ -1,3 +1,10 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
 import { KeyboardAvoidingView } from 'react-native'

--- a/src/extensions/other/wab/components/WABSquareDialog.jsx
+++ b/src/extensions/other/wab/components/WABSquareDialog.jsx
@@ -7,6 +7,7 @@ import Geolocation from '@react-native-community/geolocation'
 import { setOperationData } from '../../../../store/operations'
 import ThemedTextInput from '../../../../screens/components/ThemedTextInput'
 import { locationToWABSquare } from '../WABLocation'
+import { Info } from '../WABExtension'
 
 const VALID_WAB_REGEX = /^(W[AV][0-9]{2}|[CDGHJ][0-9]{2}|[HJNOST][A-HJ-Z][0-9]{2}|)$/
 const PARTIAL_WAB_REGEX = /^([CDGHJNOSTW]{0,1}|W[AV][0-9]{0,2}|[CDGHJ][0-9]{0,2}|[HJNOST][A-Z][0-9]{0,2})$/
@@ -72,7 +73,7 @@ export function WABSquareDialog ({ operation, visible, settings, styles, onDialo
     <Portal>
       <KeyboardAvoidingView style={{ flex: 1 }} behavior={'height'}>
         <Dialog visible={dialogVisible} onDismiss={handleCancel}>
-          <Dialog.Icon icon="map-marker-path" />
+          <Dialog.Icon icon={Info.icon} />
           <Dialog.Title style={{ textAlign: 'center' }}>Worked All Britain Square</Dialog.Title>
           <Dialog.Content>
             <Text variant="bodyMedium">Enter WAB Square</Text>

--- a/src/extensions/other/wab/components/WABSquareDialog.jsx
+++ b/src/extensions/other/wab/components/WABSquareDialog.jsx
@@ -7,14 +7,13 @@
 
 import React, { useCallback, useEffect, useState } from 'react'
 import { useDispatch } from 'react-redux'
-import { KeyboardAvoidingView } from 'react-native'
-import { Button, Dialog, Portal, Text, TouchableRipple } from 'react-native-paper'
+import { Button, Dialog, Text, TouchableRipple } from 'react-native-paper'
 import Geolocation from '@react-native-community/geolocation'
 
 import { setOperationData } from '../../../../store/operations'
 import ThemedTextInput from '../../../../screens/components/ThemedTextInput'
+import { Ham2kDialog } from '../../../../screens/components/Ham2kDialog'
 import { locationToWABSquare } from '../WABLocation'
-import { Info } from '../WABExtension'
 
 const VALID_WAB_REGEX = /^(W[AV][0-9]{2}|[CDGHJ][0-9]{2}|[HJNOST][A-HJ-Z][0-9]{2}|)$/
 const PARTIAL_WAB_REGEX = /^([CDGHJNOSTW]{0,1}|W[AV][0-9]{0,2}|[CDGHJ][0-9]{0,2}|[HJNOST][A-Z][0-9]{0,2})$/
@@ -77,37 +76,31 @@ export function WABSquareDialog ({ operation, visible, settings, styles, onDialo
   }, [])
 
   return (
-    <Portal>
-      <KeyboardAvoidingView style={{ flex: 1 }} behavior={'height'}>
-        <Dialog visible={dialogVisible} onDismiss={handleCancel}>
-          <Dialog.Icon icon={Info.icon} />
-          <Dialog.Title style={{ textAlign: 'center' }}>Worked All Britain Square</Dialog.Title>
-          <Dialog.Content>
-            <Text variant="bodyMedium">Enter WAB Square</Text>
-            <ThemedTextInput
-              style={[styles.input, { marginTop: styles.oneSpace }]}
-              value={square}
-              label="WAB Square"
-              placeholder={'e.g. SU14'}
-              onChangeText={handSquareChange}
-              error={!isValid}
-            />
-            {wabSquare && (
-              <TouchableRipple onPress={() => setSquareValue(wabSquare)} style={{ marginTop: styles.oneSpace }}>
-                <Text variant="bodyMedium" style={{ marginTop: styles.oneSpace, marginBottom: styles.oneSpace }}>
-                  <Text>Current Location Square: </Text>
-                  <Text style={{ color: styles.colors.primary, fontWeight: 'bold' }}>{wabSquare}</Text>
-                </Text>
-              </TouchableRipple>
-
-            )}
-          </Dialog.Content>
-          <Dialog.Actions>
-            <Button onPress={handleCancel}>Cancel</Button>
-            <Button onPress={handleAccept} disabled={!isValid}>Ok</Button>
-          </Dialog.Actions>
-        </Dialog>
-      </KeyboardAvoidingView>
-    </Portal>
+    <Ham2kDialog visible={dialogVisible} onDismiss={handleCancel}>
+      <Dialog.Title style={{ textAlign: 'center' }}>Worked All Britain Square</Dialog.Title>
+      <Dialog.Content>
+        <Text variant="bodyMedium">Enter WAB Square</Text>
+        <ThemedTextInput
+          style={[styles.input, { marginTop: styles.oneSpace }]}
+          value={square}
+          label="WAB Square"
+          placeholder={'e.g. SU14'}
+          onChangeText={handSquareChange}
+          error={!isValid}
+        />
+        {wabSquare && (
+          <TouchableRipple onPress={() => setSquareValue(wabSquare)} style={{ marginTop: styles.oneSpace }}>
+            <Text variant="bodyMedium" style={{ marginTop: styles.oneSpace, marginBottom: styles.oneSpace }}>
+              <Text>Current Square: </Text>
+              <Text style={{ color: styles.colors.primary, fontWeight: 'bold' }}>{wabSquare}</Text>
+            </Text>
+          </TouchableRipple>
+        )}
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button onPress={handleCancel}>Cancel</Button>
+        <Button onPress={handleAccept} disabled={!isValid}>Ok</Button>
+      </Dialog.Actions>
+    </Ham2kDialog>
   )
 }

--- a/src/extensions/other/wab/components/WABSquareDialog.jsx
+++ b/src/extensions/other/wab/components/WABSquareDialog.jsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { useDispatch } from 'react-redux'
+import { KeyboardAvoidingView } from 'react-native'
+import { Button, Dialog, Portal, Text, TouchableRipple } from 'react-native-paper'
+import Geolocation from '@react-native-community/geolocation'
+
+import { setOperationData } from '../../../../store/operations'
+import ThemedTextInput from '../../../../screens/components/ThemedTextInput'
+import { locationToWABSquare } from '../WABLocation'
+
+const VALID_WAB_REGEX = /^(W[AV][0-9]{2}|[CDGHJ][0-9]{2}|[HJNOST][A-HJ-Z][0-9]{2}|)$/
+const PARTIAL_WAB_REGEX = /^([CDGHJNOSTW]{0,1}|W[AV][0-9]{0,2}|[CDGHJ][0-9]{0,2}|[HJNOST][A-Z][0-9]{0,2})$/
+
+export function WABSquareDialog ({ operation, visible, settings, styles, onDialogDone }) {
+  const dispatch = useDispatch()
+
+  const [dialogVisible, setDialogVisible] = useState(false)
+
+  const [square, setSquareValue] = useState('')
+  const [isValid, setIsValidValue] = useState()
+
+  useEffect(() => {
+    setDialogVisible(visible)
+  }, [visible])
+
+  useEffect(() => {
+    setSquareValue(operation?.wabSquare || '')
+  }, [operation])
+
+  useEffect(() => {
+    setIsValidValue(VALID_WAB_REGEX.test(square))
+  }, [square])
+
+  const handSquareChange = useCallback((text) => {
+    text = text.toUpperCase()
+    if (PARTIAL_WAB_REGEX.test(text)) {
+      setSquareValue(text)
+    }
+  }, [setSquareValue])
+
+  const handleAccept = useCallback(() => {
+    if (isValid) {
+      dispatch(setOperationData({ uuid: operation.uuid, wabSquare: square }))
+    }
+    setDialogVisible(false)
+    onDialogDone && onDialogDone()
+  }, [dispatch, operation, square, isValid, onDialogDone])
+
+  const handleCancel = useCallback(() => {
+    setSquareValue(operation.grid)
+    setDialogVisible(false)
+    onDialogDone && onDialogDone()
+  }, [setSquareValue, operation.grid, setDialogVisible, onDialogDone])
+
+  const [wabSquare, setWABSquare] = useState()
+  useEffect(() => {
+    Geolocation.getCurrentPosition(info => {
+      const { latitude, longitude } = info.coords
+      setWABSquare(locationToWABSquare(latitude, longitude))
+    })
+
+    const watchId = Geolocation.watchPosition(info => {
+      const { latitude, longitude } = info.coords
+      setWABSquare(locationToWABSquare(latitude, longitude))
+    })
+    return () => {
+      Geolocation.clearWatch(watchId)
+    }
+  }, [])
+
+  return (
+    <Portal>
+      <KeyboardAvoidingView style={{ flex: 1 }} behavior={'height'}>
+        <Dialog visible={dialogVisible} onDismiss={handleCancel}>
+          <Dialog.Icon icon="map-marker-path" />
+          <Dialog.Title style={{ textAlign: 'center' }}>Worked All Britain Square</Dialog.Title>
+          <Dialog.Content>
+            <Text variant="bodyMedium">Enter WAB Square</Text>
+            <ThemedTextInput
+              style={[styles.input, { marginTop: styles.oneSpace }]}
+              value={square}
+              label="WAB Square"
+              placeholder={'e.g. SU14'}
+              onChangeText={handSquareChange}
+              error={!isValid}
+            />
+            {wabSquare && (
+              <TouchableRipple onPress={() => setSquareValue(wabSquare)} style={{ marginTop: styles.oneSpace }}>
+                <Text variant="bodyMedium" style={{ marginTop: styles.oneSpace, marginBottom: styles.oneSpace }}>
+                  <Text>Current Location Square: </Text>
+                  <Text style={{ color: styles.colors.primary, fontWeight: 'bold' }}>{wabSquare}</Text>
+                </Text>
+              </TouchableRipple>
+
+            )}
+          </Dialog.Content>
+          <Dialog.Actions>
+            <Button onPress={handleCancel}>Cancel</Button>
+            <Button onPress={handleAccept} disabled={!isValid}>Ok</Button>
+          </Dialog.Actions>
+        </Dialog>
+      </KeyboardAvoidingView>
+    </Portal>
+  )
+}

--- a/src/extensions/registry.js
+++ b/src/extensions/registry.js
@@ -24,7 +24,8 @@ const Hooks = {
   activity: [],
   command: [],
   screen: [],
-  setting: []
+  setting: [],
+  opSetting: []
 }
 
 const VALID_HOOK_REGEX = /^(ref:\w+)/

--- a/src/screens/OperationScreens/OpSettingsTab/OpSettingsTab.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OpSettingsTab.jsx
@@ -87,6 +87,7 @@ export default function OpSettingsTab ({ navigation, route }) {
   }, [operation?.refs])
 
   const activityHooks = useMemo(() => findHooks('activity'), [])
+  const opSettingsHooks = useMemo(() => findHooks('opSetting'), [])
 
   return (
     <ScrollView style={{ flex: 1 }}>
@@ -123,6 +124,10 @@ export default function OpSettingsTab ({ navigation, route }) {
             onDialogDone={() => setCurrentDialog('')}
           />
         )}
+
+        {opSettingsHooks.filter(hook => hook.category === 'detail').map((hook) => (
+          <hook.OpSettingItem key={hook.key} operation={operation} styles={styles} settings={settings} />
+        ))}
       </Ham2kListSection>
 
       <Ham2kListSection title={'Activities'}>


### PR DESCRIPTION
This requires additional package *proj4* for coordinate projection for identifying WAB square from latitude/longitude of device location.

This introduces a new hook for `opSettings` for per operation parameters. This felt like a better approach, as WAB isn't an activity as such, just fact of your location, and is something that is "hunted", and has no requirement to export/upload logs, etc.

Currently WAB square isn't export, but extension could be extended to include adding to `COMMENT` field in ADIF (as is of interest to hunter, not logger) or custom field.