### PR TITLE
Add UKBOTA extension

### DIFF
--- a/src/extensions/activities/custom/CustomExtension.js
+++ b/src/extensions/activities/custom/CustomExtension.js
@@ -70,6 +70,8 @@ const ReferenceHandler = {
     return [ref.ref, ref.name].filter(x => x).join(' • ')
   },
 
+  incQsoItemIcon: true,
+
   decorateRef: (ref) => {
     return ref // Custom so no known extra data
   },

--- a/src/extensions/activities/pota/POTAExtension.js
+++ b/src/extensions/activities/pota/POTAExtension.js
@@ -99,6 +99,8 @@ const ReferenceHandler = {
     ].filter(x => x).join(' • ')
   },
 
+  incQsoItemIcon: true,
+
   decorateRefWithDispatch: (ref) => async () => {
     if (!ref?.ref || !ref.ref.match(Info.referenceRegex)) return { ...ref, ref: '', name: '', shortName: '', location: '' }
 

--- a/src/extensions/activities/sota/SOTAExtension.js
+++ b/src/extensions/activities/sota/SOTAExtension.js
@@ -92,6 +92,8 @@ const ReferenceHandler = {
     return [ref.ref, ref.name].filter(x => x).join(' • ')
   },
 
+  incQsoItemIcon: true,
+
   decorateRefWithDispatch: (ref) => async () => {
     if (ref.ref) {
       const data = await sotaFindOneByReference(ref.ref)

--- a/src/extensions/activities/ukbota/UKBOTAActivityOptions.jsx
+++ b/src/extensions/activities/ukbota/UKBOTAActivityOptions.jsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useState, useEffect, useMemo, useCallback } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Searchbar } from 'react-native-paper'
+import Geolocation from '@react-native-community/geolocation'
+
+import { selectOperationCallInfo, setOperationData } from '../../../store/operations'
+import { filterRefs, replaceRefs } from '../../../tools/refTools'
+import { selectRuntimeOnline } from '../../../store/runtime'
+import { ListRow } from '../../../screens/components/ListComponents'
+import { distanceOnEarth } from '../../../tools/geoTools'
+import { reportError } from '../../../App'
+import { Ham2kListSection } from '../../../screens/components/Ham2kListSection'
+
+import { Info } from './UKBOTAInfo'
+import { ukbotaFindAllByLocation, ukbotaFindAllByName, ukbotaFindOneByReference } from './UKBOTADataFile'
+import { UKBOTAListItem } from './UKBOTAListItem'
+
+export function UKBOTAActivityOptions (props) {
+  const NEARBY_DEGREES = 0.25
+
+  const { styles, operation, settings } = props
+
+  const dispatch = useDispatch()
+
+  const online = useSelector(selectRuntimeOnline)
+
+  const ourInfo = useSelector(state => selectOperationCallInfo(state, operation?.uuid))
+
+  const refs = useMemo(() => filterRefs(operation, Info.activationType).filter(ref => ref.ref), [operation])
+
+  const title = useMemo(() => {
+    if (refs?.length === 0) return 'No bunkers selected for activation'
+    else if (refs?.length === 1) return 'Activating 1 bunker'
+    else return `Activating ${refs.length} bunkers`
+  }, [refs])
+
+  const [search, setSearch] = useState('')
+
+  const [results, setResults] = useState([])
+  const [resultsMessage, setResultsMessage] = useState([])
+
+  const [location, setLocation] = useState()
+  useEffect(() => {
+    Geolocation.getCurrentPosition(info => {
+      const { latitude, longitude } = info.coords
+      setLocation({ lat: latitude, lon: longitude })
+    }, error => {
+      reportError('Geolocation error', error)
+      setLocation(undefined)
+    })
+  }, [])
+
+  const [refDatas, setRefDatas] = useState([])
+  useEffect(() => {
+    setTimeout(async () => {
+      const datas = []
+      for (const ref of refs) {
+        const result = await ukbotaFindOneByReference(ref.ref)
+        const newData = { ...ref, ...result }
+        if (location?.lat && location?.lon) {
+          newData.distance = distanceOnEarth(newData, location, { units: settings.distanceUnits })
+        }
+        datas.push(newData)
+      }
+      setRefDatas(datas)
+    }, 0)
+  }, [refs, location, settings.distanceUnits])
+
+  const [nearbyResults, setNearbyResults] = useState([])
+  useEffect(() => {
+    setTimeout(async () => {
+      if (location?.lat && location?.lon) {
+        const newResults = await ukbotaFindAllByLocation(ourInfo?.entityPrefix, location.lat, location.lon, NEARBY_DEGREES)
+        setNearbyResults(
+          newResults.map(result => ({
+            ...result,
+            distance: distanceOnEarth(result, location, { units: settings.distanceUnits })
+          })).sort((a, b) => a.distance - b.distance)
+        )
+      }
+    })
+  }, [ourInfo, location, settings.distanceUnits])
+
+  useEffect(() => {
+    setTimeout(async () => {
+      if (search?.length > 2) {
+        let newRefs = await ukbotaFindAllByName(ourInfo?.entityPrefix, search.toLowerCase())
+        if (location?.lat && location?.lon) {
+          newRefs = newRefs.map(ref => ({
+            ...ref,
+            distance: distanceOnEarth(ref, location, { units: settings.distanceUnits })
+          })).sort((a, b) => a.distance - b.distance)
+        }
+
+        let nakedReference
+        const parts = search.match(/^\s*(B\/G[DIJMUW]?)-?(\d+)\s*$/i)
+        if (parts && parts[2].length >= 4) {
+          nakedReference = (parts[1]?.toUpperCase() || `B/${ourInfo?.entityPrefix}` || 'B/G') + '-' + parts[2].toUpperCase()
+        } else if (search.match(Info.referenceRegex)) {
+          nakedReference = search
+        }
+
+        // If it's a naked reference, let's ensure the results include it, or else add a placeholder
+        // just to cover any cases where the user knows about a new reference not included in our data
+        if (nakedReference && !newRefs.find(ref => ref.ref === nakedReference)) {
+          newRefs.unshift({ ref: nakedReference })
+        }
+
+        setResults(newRefs.slice(0, 15))
+        if (newRefs.length === 0) {
+          setResultsMessage('No bunkers found')
+        } else if (newRefs.length > 15) {
+          setResultsMessage(`Nearest 15 of ${newRefs.length} matches`)
+        } else if (newRefs.length === 1) {
+          setResultsMessage('One matching bunkers')
+        } else {
+          setResultsMessage(`${newRefs.length} matching bunkers`)
+        }
+      } else {
+        setResults(nearbyResults)
+        if (nearbyResults === undefined) setResultsMessage('Search for some bunkers to activate!')
+        else if (nearbyResults.length === 0) setResultsMessage('No bunkers nearby')
+        else setResultsMessage('Nearby bunkers')
+      }
+    })
+  }, [search, ourInfo, nearbyResults, location, settings.distanceUnits])
+
+  const handleAddReference = useCallback((ref) => {
+    dispatch(setOperationData({ uuid: operation.uuid, refs: replaceRefs(operation?.refs, Info.activationType, [...refs.filter(r => r.ref !== ref), { type: Info.activationType, ref }]) }))
+  }, [dispatch, operation, refs])
+
+  const handleRemoveReference = useCallback((ref) => {
+    dispatch(setOperationData({ uuid: operation.uuid, refs: replaceRefs(operation?.refs, Info.activationType, refs.filter(r => r.ref !== ref)) }))
+  }, [dispatch, operation, refs])
+
+  return (
+    <>
+      <Ham2kListSection title={title}>
+        {refDatas.map((bunker, index) => (
+          <UKBOTAListItem
+            key={bunker.ref}
+            activityRef={bunker.ref}
+            refData={bunker}
+            allRefs={refs}
+            styles={styles}
+            settings={settings}
+            online={online}
+            onAddReference={handleAddReference}
+            onRemoveReference={handleRemoveReference}
+          />
+        ))}
+      </Ham2kListSection>
+
+      <ListRow>
+        <Searchbar
+          placeholder={'Bunkers by name or reference…'}
+          value={search}
+          onChangeText={setSearch}
+        />
+      </ListRow>
+
+      <Ham2kListSection title={resultsMessage}>
+        {results.map((ref) => (
+          <UKBOTAListItem
+            key={ref.ref}
+            activityRef={ref.ref}
+            allRefs={refs}
+            refData={ref}
+            styles={styles}
+            settings={settings}
+            onPress={() => handleAddReference(ref.ref) }
+            onAddReference={handleAddReference}
+            onRemoveReference={handleRemoveReference}
+          />
+        ))}
+      </Ham2kListSection>
+    </>
+  )
+}

--- a/src/extensions/activities/ukbota/UKBOTADataFile.js
+++ b/src/extensions/activities/ukbota/UKBOTADataFile.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import RNFetchBlob from 'react-native-blob-util'
+import { fmtNumber, fmtPercent } from '@ham2k/lib-format-tools'
+
+import packageJson from '../../../../package.json'
+
+import { registerDataFile } from '../../../store/dataFiles'
+import { database, dbExecute, dbSelectAll, dbSelectOne } from '../../../store/db/db'
+import { fmtDateNice } from '../../../tools/timeFormats'
+
+export const UKBOTAData = { }
+
+export function registerUKBOTADataFile () {
+  registerDataFile({
+    key: 'ukbota-all-bunkers',
+    name: 'UKBOTA: All Bunkers',
+    description: 'Database of all UKBOTA references',
+    infoURL: 'https://bunkerbase.org',
+    icon: 'file-cloud-outline',
+    maxAgeInDays: 7,
+    enabledByDefault: true,
+    fetch: async ({ key, definition, options }) => {
+      options.onStatus && await options.onStatus({ key, definition, status: 'progress', progress: 'Downloading raw data' })
+
+      const url = 'https://drive.google.com/uc?id=1ea3j9S4VzcDttMPs_9WOj-4L_DzfcUhR'
+
+      const response = await RNFetchBlob.config({ fileCache: true }).fetch('GET', url, {
+        'User-Agent': `Ham2K Portable Logger/${packageJson.version}`
+      })
+      const body = await RNFetchBlob.fs.readFile(response.data, 'utf8')
+
+      const lines = body.split('\n')
+      const headers = parseUKBOTACSVRow(lines.shift())
+      headers[0] = headers[0].replace(/^\uFEFF/, '')
+
+      let totalReferences = 0
+
+      const db = await database()
+      db.transaction(transaction => {
+        transaction.executeSql('UPDATE lookups SET updated = 0 WHERE category = ?', ['ukbota'])
+      })
+
+      const startTime = Date.now()
+      let processedLines = 0
+      const totalLines = lines.length
+
+      while (lines.length > 0) {
+        const batch = lines.splice(0, 500)
+        await (() => new Promise(resolve => {
+          setTimeout(() => {
+            db.transaction(async transaction => {
+              for (const line of batch) {
+                const row = parseUKBOTACSVRow(line, { headers })
+                const ref = row['UKBOTA Reference']
+                if (ref) {
+                  row.Maidenhead &&= row.Maidenhead.replace(/[A-Z]{2}$/, x => x.toLowerCase())
+                  const data = {
+                    ref,
+                    entityPrefix: ref.split('-')[0].split('/')[1],
+                    name: row['Bunker Name'],
+                    area: row.Area,
+                    grid: row.Maidenhead,
+                    lat: Number.parseFloat(row.Latitude),
+                    lon: Number.parseFloat(row.Longitude)
+                  }
+
+                  totalReferences++
+                  transaction.executeSql(`
+                  INSERT INTO lookups
+                    (category, subCategory, key, name, data, lat, lon, flags, updated)
+                  VALUES
+                    (?, ?, ?, ?, ?, ?, ?, ?, 1)
+                  ON CONFLICT DO
+                  UPDATE SET
+                    subCategory = ?, name = ?, data = ?, lat = ?, lon = ?, flags = ?, updated = 1
+                  `, ['ukbota', data.entityPrefix, data.ref, data.name, JSON.stringify(data), data.lat, data.lon, 1, data.entityPrefix, data.name, JSON.stringify(data), data.lat, data.lon, 1]
+                  )
+                }
+                processedLines++
+              }
+              options.onStatus && await options.onStatus({
+                key,
+                definition,
+                status: 'progress',
+                progress: `Loaded \`${fmtNumber(processedLines)}\` references.\n\n\`${fmtPercent(Math.min(processedLines / totalLines, 1), 'integer')}\` • ${fmtNumber((totalLines - processedLines) * ((Date.now() - startTime) / 1000) / processedLines, 'oneDecimal')} seconds left.`
+              })
+              resolve()
+            })
+          }, 0)
+        }))()
+      }
+
+      db.transaction(transaction => {
+        transaction.executeSql('DELETE FROM lookups WHERE category = ? AND updated = 0', ['ukbota'])
+      })
+
+      const data = {
+        totalReferences,
+        version: fmtDateNice(new Date())
+      }
+
+      RNFetchBlob.fs.unlink(response.data)
+
+      return data
+    },
+    onLoad: (data) => {
+      UKBOTAData.totalRefs = data.totalRefs
+      UKBOTAData.version = data.version
+    },
+    onRemove: async () => {
+      await dbExecute('DELETE FROM lookups WHERE category = ?', ['ukbota'])
+    }
+  })
+}
+
+export async function ukbotaFindOneByReference (ref) {
+  return await dbSelectOne('SELECT data FROM lookups WHERE category = ? AND key = ?', ['ukbota', ref], { row: row => row?.data ? JSON.parse(row.data) : {} })
+}
+
+export async function ukbotaFindAllByName (entityPrefix, name) {
+  const results = await dbSelectAll(
+    'SELECT data FROM lookups WHERE category = ? AND subCategory = ? AND (key LIKE ? OR name LIKE ?) AND flags = 1',
+    ['ukbota', entityPrefix, `%${name}%`, `%${name}%`],
+    { row: row => JSON.parse(row.data) }
+  )
+  return results
+}
+
+export async function ukbotaFindAllByLocation (entityPrefix, lat, lon, delta = 1) {
+  const results = await dbSelectAll(
+    'SELECT data FROM lookups WHERE category = ? AND subCategory = ? AND lat BETWEEN ? AND ? AND lon BETWEEN ? AND ? AND flags = 1',
+    ['ukbota', entityPrefix, lat - delta, lat + delta, lon - delta, lon + delta],
+    { row: row => JSON.parse(row.data) }
+  )
+  return results
+}
+
+const OPTIONAL_QUOTED_CSV_ROW_REGEX = /(?<=^|,)(?:(?:"((?:[^"]|"")*)")|([^,]*))(?:,|$)/g
+function parseUKBOTACSVRow (row, options) {
+  const parts = [...row.matchAll(OPTIONAL_QUOTED_CSV_ROW_REGEX)].map(
+    match => match[1] ? match[1].replaceAll('""', '"') : match[2])
+  if (options?.headers) {
+    const obj = {}
+    options.headers.forEach((column, index) => {
+      obj[column] = parts[index]
+    })
+    return obj
+  } else {
+    return parts
+  }
+}

--- a/src/extensions/activities/ukbota/UKBOTAExtension.js
+++ b/src/extensions/activities/ukbota/UKBOTAExtension.js
@@ -159,5 +159,11 @@ const ReferenceHandler = {
     } else {
       return [activationADIF]
     }
+  },
+
+  adifHeaderComment: ({ qsos, operation, common }) => {
+    const b2bCount = qsos.reduce((count, qso) => count + filterRefs(qso, Info.huntingType).length, 0)
+    const stationsWorked = new Set(qsos.map(qso => qso.their?.call + qso.band)).size
+    return `Stations Worked: ${stationsWorked}\nB2B QSOs: ${b2bCount}\n`
   }
 }

--- a/src/extensions/activities/ukbota/UKBOTAExtension.js
+++ b/src/extensions/activities/ukbota/UKBOTAExtension.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { loadDataFile, removeDataFile } from '../../../store/dataFiles/actions/dataFileFS'
+import { filterRefs, findRef, refsToString } from '../../../tools/refTools'
+
+import { Info } from './UKBOTAInfo'
+import { UKBOTAActivityOptions } from './UKBOTAActivityOptions'
+import { ukbotaFindOneByReference, registerUKBOTADataFile } from './UKBOTADataFile'
+import { UKBOTALoggingControl } from './UKBOTALoggingControl'
+
+const Extension = {
+  ...Info,
+  category: 'locationBased',
+  onActivationDispatch: ({ registerHook }) => async (dispatch) => {
+    registerHook('activity', { hook: ActivityHook })
+    registerHook(`ref:${Info.huntingType}`, { hook: ReferenceHandler })
+    registerHook(`ref:${Info.activationType}`, { hook: ReferenceHandler })
+
+    registerUKBOTADataFile()
+    await dispatch(loadDataFile('ukbota-all-bunkers', { noticesInsteadOfFetch: true }))
+  },
+  onDeactivationDispatch: () => async (dispatch) => {
+    await dispatch(removeDataFile('ukbota-all-bunkers'))
+  }
+}
+export default Extension
+
+const ActivityHook = {
+  ...Info,
+  MainExchangePanel: null,
+  loggingControls: ({ operation, settings }) => {
+    if (findRef(operation, Info.activationType)) {
+      return [ActivatorLoggingControl]
+    } else {
+      return [HunterLoggingControl]
+    }
+  },
+  Options: UKBOTAActivityOptions,
+
+  includeControlForQSO: ({ qso, operation }) => {
+    if (findRef(operation, Info.activationType)) return true
+    if (findRef(qso, Info.huntingType)) return true
+    else return false
+  },
+
+  labelControlForQSO: ({ operation, qso }) => {
+    const opRef = findRef(operation, Info.activationType)
+    let label = opRef ? Info.shortNameDoubleContact : Info.shortName
+    if (findRef(qso, Info.huntingType)) label = `✓ ${label}`
+    return label
+  }
+}
+
+const HunterLoggingControl = {
+  key: `${Info.key}/hunter`,
+  order: 10,
+  icon: Info.icon,
+  label: ({ operation, qso }) => {
+    const parts = [Info.shortName]
+    if (findRef(qso, Info.huntingType)) parts.unshift('✓')
+    return parts.join(' ')
+  },
+  InputComponent: UKBOTALoggingControl,
+  optionType: 'optional'
+}
+
+const ActivatorLoggingControl = {
+  key: `${Info.key}/activator`,
+  order: 10,
+  icon: Info.icon,
+  label: ({ operation, qso }) => {
+    const parts = [Info.shortNameDoubleContact]
+    if (findRef(qso, Info.huntingType)) parts.unshift('✓')
+    return parts.join(' ')
+  },
+  InputComponent: UKBOTALoggingControl,
+  optionType: 'mandatory'
+}
+
+const ReferenceHandler = {
+  ...Info,
+
+  shortDescription: (operation) => refsToString(operation, Info.activationType),
+
+  description: (operation) => {
+    const refs = filterRefs(operation, Info.activationType)
+    return [
+      refs.map(r => r.ref).filter(x => x).join(', '),
+      refs.map(r => r.name).filter(x => x).join(', ')
+    ].filter(x => x).join(' • ')
+  },
+
+  incQsoItemIcon: true,
+
+  decorateRefWithDispatch: (ref) => async () => {
+    if (!ref?.ref || !ref.ref.match(Info.referenceRegex)) return { ...ref, ref: '', name: '', location: '' }
+
+    const data = await ukbotaFindOneByReference(ref.ref)
+    let result
+    if (data?.name) {
+      result = {
+        ...ref,
+        name: data.name,
+        location: data.area,
+        grid: data.grid
+      }
+    } else {
+      return { ...ref, name: Info.unknownReferenceName ?? 'Unknown reference' }
+    }
+    return result
+  },
+
+  suggestOperationTitle: (ref) => {
+    if (ref.type === Info.activationType && ref.ref) {
+      return { at: ref.ref, subtitle: ref.name }
+    } else {
+      return null
+    }
+  },
+
+  suggestExportOptions: ({ operation, ref, settings }) => {
+    if (ref.type === Info.activationType && ref.ref) {
+      return [{
+        format: 'adif',
+        common: { refs: [ref] },
+        nameTemplate: settings.useCompactFileNames ? '{call}@{ref}-{compactDate}' : '{date} {call} at {ref}',
+        titleTemplate: `{call}: ${Info.shortName} at ${[ref.ref, ref.name].filter(x => x).join(' - ')} on {date}`
+      }]
+    }
+  },
+
+  adifFieldsForOneQSO: ({ qso, operation, common }) => {
+    const huntingRefs = filterRefs(qso, Info.huntingType)
+
+    if (huntingRefs) return ([{ SIG: 'UKBOTA' }, { SIG_INFO: huntingRefs.map(ref => ref.ref).filter(x => x).join(',') }])
+    else return []
+  },
+
+  adifFieldCombinationsForOneQSO: ({ qso, operation, common }) => {
+    const huntingRefs = filterRefs(qso, Info.huntingType)
+    const activationRef = findRef(operation, Info.activationType)
+    let activationADIF = []
+    if (activationRef) {
+      activationADIF = [
+        { MY_SIG: 'UKBOTA' }, { MY_SIG_INFO: activationRef.ref }
+      ]
+    }
+
+    if (huntingRefs.length > 0) {
+      return [[
+        ...activationADIF,
+        { SIG: 'UKBOTA' }, { SIG_INFO: huntingRefs.map(ref => ref.ref).filter(x => x).join(',') }
+      ]]
+    } else {
+      return [activationADIF]
+    }
+  }
+}

--- a/src/extensions/activities/ukbota/UKBOTAInfo.js
+++ b/src/extensions/activities/ukbota/UKBOTAInfo.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+export const Info = {
+  key: 'ukbota',
+  icon: 'nuke',
+  name: 'UK Bunkers on the Air',
+  shortName: 'UKBOTA',
+  doubleContact: 'Bunker-to-Bunker',
+  shortNameDoubleContact: 'B2B',
+  infoURL: 'https://bunkersontheair.org/',
+  huntingType: 'ukbota',
+  activationType: 'ukbotaActivation',
+  descriptionPlaceholder: 'Enter UKBOTA references',
+  unknownReferenceName: 'Unknown Bunker',
+  referenceRegex: /^B\/G[DIJMUW]?-[0-9]{4}$/i
+}

--- a/src/extensions/activities/ukbota/UKBOTAInput.jsx
+++ b/src/extensions/activities/ukbota/UKBOTAInput.jsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useCallback } from 'react'
+
+import { useThemedStyles } from '../../../styles/tools/useThemedStyles'
+import ThemedTextInput from '../../../screens/components/ThemedTextInput'
+
+const ADD_DASHES_REGEX = /([A-Z]+)(\d+)/gi
+const ADD_SLASHES_REGEX = /(B)?((?<!\/)G[DIJMUW]?)/gi
+const ADD_COMMAS_REGEX = /(\d\d+)\s*[,]*\s*([A-Z]+)/gi
+const NO_PREFIX_REGEX = /^(\d\d+)/gi
+const REPEAT_PREFIX_REGEX = /([\w/]+)-(\d+)(\s+,\s*|,\s*|\s+)(\d\d+)/gi
+
+export default function UKBOTAInput (props) {
+  const { textStyle, onChange, defaultPrefix, onChangeText, fieldId } = props
+
+  const styles = useThemedStyles()
+
+  const handleChange = useCallback((event) => {
+    let { text } = event.nativeEvent
+
+    text = text.replace(NO_PREFIX_REGEX, (match, p1, p2) => `${defaultPrefix ?? 'B/G'}-${p1}`)
+    text = text.replace(ADD_SLASHES_REGEX, (match, p1, p2) => `B/${p2}`)
+    text = text.replace(ADD_DASHES_REGEX, (match, p1, p2) => `${p1}-${p2}`)
+    text = text.replace(ADD_COMMAS_REGEX, (match, p1, p2) => `${p1}, ${p2}`)
+    text = text.replace(REPEAT_PREFIX_REGEX, (match, p1, p2, p3, p4) => `${p1}-${p2}, ${p1}-${p4}`)
+
+    event.nativeEvent.text = text
+
+    onChangeText && onChangeText(text)
+    onChange && onChange({ ...event, fieldId })
+  }, [onChange, onChangeText, fieldId, defaultPrefix])
+
+  return (
+    <ThemedTextInput
+      {...props}
+      keyboard="dumb"
+      uppercase={true}
+      nospaces={true}
+      placeholder={`${defaultPrefix ?? 'B/G'}-…`}
+      textStyle={[textStyle, styles?.text?.callsign]}
+      onChange={handleChange}
+    />
+  )
+}

--- a/src/extensions/activities/ukbota/UKBOTAListItem.jsx
+++ b/src/extensions/activities/ukbota/UKBOTAListItem.jsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* eslint-disable react/no-unstable-nested-components */
+import React, { useEffect, useMemo, useState } from 'react'
+import { IconButton, List, Text } from 'react-native-paper'
+import { View } from 'react-native'
+
+import { fmtDistance } from '../../../tools/geoTools'
+
+import { Info } from './UKBOTAInfo'
+import { ukbotaFindOneByReference } from './UKBOTADataFile'
+import { Ham2kListItem } from '../../../screens/components/Ham2kListItem'
+
+export function UKBOTAListItem ({ activityRef, refData, allRefs, style, styles, settings, onPress, onAddReference, onRemoveReference, online }) {
+  const [reference, setReference] = useState()
+  useEffect(() => {
+    ukbotaFindOneByReference(activityRef).then(setReference)
+  }, [activityRef])
+
+  const isInRefs = useMemo(() => {
+    return allRefs.find(ref => ref.ref === activityRef)
+  }, [allRefs, activityRef])
+
+  return (
+    <Ham2kListItem style={{ paddingRight: styles.oneSpace * 1 }}
+      title={
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: styles.oneSpace }}>
+          <Text style={{ fontWeight: 'bold' }}>
+            {reference?.ref ?? activityRef}
+          </Text>
+          <Text>
+            {refData?.distance && fmtDistance(refData.distance, { units: settings.distanceUnits }) + ' away'}
+          </Text>
+        </View>
+      }
+      description={[reference?.name, reference?.area].filter(x => x).join(', ')}
+      onPress={onPress}
+      left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon={Info.icon} />}
+      right={() => (
+        isInRefs ? (
+          onRemoveReference && <IconButton icon="minus-circle-outline" onPress={() => onRemoveReference(activityRef)} />
+        ) : (
+          onAddReference && <IconButton icon="plus-circle" onPress={() => onAddReference(activityRef)} />
+        )
+      )}
+    />
+  )
+}

--- a/src/extensions/activities/ukbota/UKBOTALoggingControl.jsx
+++ b/src/extensions/activities/ukbota/UKBOTALoggingControl.jsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useSelector } from 'react-redux'
+
+import { filterRefs, refsToString, replaceRefs, stringToRefs } from '../../../tools/refTools'
+import { selectOperationCallInfo } from '../../../store/operations'
+
+import { Info } from './UKBOTAInfo'
+import UKBOTAInput from './UKBOTAInput'
+
+export function UKBOTALoggingControl (props) {
+  const { qso, operation, updateQSO, style, styles } = props
+
+  const ref = useRef()
+  useEffect(() => { setTimeout(() => ref?.current?.focus(), 0) }, [])
+
+  const ourInfo = useSelector(state => selectOperationCallInfo(state, operation?.uuid))
+
+  const [localValue, setLocalValue] = useState('')
+
+  // Only initialize localValue once
+  useEffect(() => {
+    const refs = filterRefs(qso, Info.huntingType)
+    if (!localValue) {
+      setLocalValue(refsToString(refs, Info.huntingType))
+    }
+  }, [qso, localValue])
+
+  const localHandleChangeText = useCallback((value) => {
+    setLocalValue(value)
+    const refs = stringToRefs(Info.huntingType, value, { regex: Info.referenceRegex })
+
+    updateQSO({ refs: replaceRefs(qso?.refs, Info.huntingType, refs) })
+  }, [qso, updateQSO])
+
+  const defaultPrefix = useMemo(() => {
+    if (qso?.their?.guess?.entityPrefix?.[0] === 'G') {
+      return `B/${qso?.their.guess.entityPrefix}`
+    } else if (ourInfo?.entityPrefix?.[0] === 'G') {
+      return `B/${ourInfo?.entityPrefix}`
+    } else {
+      return '?'
+    }
+  }, [qso?.their?.guess?.entityPrefix, ourInfo?.entityPrefix])
+
+  return (
+    <UKBOTAInput
+      {...props}
+      innerRef={ref}
+      style={[style, { minWidth: 16 * styles.oneSpace }]}
+      value={localValue}
+      label="Their Bunker"
+      defaultPrefix={defaultPrefix}
+      onChangeText={localHandleChangeText}
+    />
+  )
+}

--- a/src/extensions/activities/wwff/WWFFExtension.js
+++ b/src/extensions/activities/wwff/WWFFExtension.js
@@ -89,6 +89,8 @@ const ReferenceHandler = {
 
   description: (operation) => refsToString(operation, Info.activationType),
 
+  incQsoItemIcon: true,
+
   decorateRefWithDispatch: (ref) => async () => {
     if (ref.ref) {
       const data = await wwffFindOneByReference(ref.ref)

--- a/src/extensions/loadExtensions.js
+++ b/src/extensions/loadExtensions.js
@@ -15,6 +15,7 @@ import WWFFExtension from './activities/wwff/WWFFExtension'
 import FDExtension from './activities/fd/FDExtension'
 import WFDExtension from './activities/wfd/WFDExtension'
 import CustomExtension from './activities/custom/CustomExtension'
+import UKBOTAExtension from './activities/ukbota/UKBOTAExtension'
 
 import RadioCommands from './commands/RadioCommands'
 import TimeCommands from './commands/TimeCommands'
@@ -32,6 +33,7 @@ const loadExtensions = () => async (dispatch, getState) => {
   registerExtension(CustomExtension)
   registerExtension(WFDExtension)
   registerExtension(FDExtension)
+  registerExtension(UKBOTAExtension)
 
   registerExtension(RadioCommands)
   registerExtension(TimeCommands)

--- a/src/screens/OperationScreens/OpLoggingTab/components/QSOItem.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/QSOItem.jsx
@@ -21,13 +21,6 @@ export function guessItemHeight (qso, styles) {
   return styles.compactRow.height + styles.compactRow.borderBottomWidth
 }
 
-const REFS_TO_INCLUDE = {
-  pota: true,
-  sota: true,
-  wwff: true,
-  custom: true
-}
-
 const QSOItem = React.memo(function QSOItem ({ qso, ourInfo, onPress, styles, selected, settings }) {
   const theirInfo = useMemo(() => {
     if (qso?.their?.entityPrefix) {
@@ -82,7 +75,7 @@ const QSOItem = React.memo(function QSOItem ({ qso, ourInfo, onPress, styles, se
           {qso.notes && (
             <Icon source="note-outline" size={styles.normalFontSize} style={styles.fields.icon} />
           )}
-          {(qso.refs || []).filter(ref => REFS_TO_INCLUDE[ref.type]).map(ref => ({ ref, handler: findBestHook(`ref:${ref.type}`) })).map(({ ref, handler }, i) => (
+          {(qso.refs || []).map(ref => ({ ref, handler: findBestHook(`ref:${ref.type}`) })).filter(x => x.handler?.incQsoItemIcon).map(({ ref, handler }, i) => (
             <Icon key={i} source={handler?.icon} size={styles.normalFontSize} style={styles.fields.icon} color={styles.fields.icon.color} />
           ))}
         </Text>

--- a/src/tools/qsonToADIF.js
+++ b/src/tools/qsonToADIF.js
@@ -23,6 +23,7 @@ export function qsonToADIF ({ operation, settings, qsos, handler, otherHandlers,
   let str = ''
 
   str += `ADIF for ${title || operation?.title || 'Operation'} \n`
+  if (handler?.adifHeaderComment) str += handler.adifHeaderComment({qsos, operation, common})
   str += adifField('ADIF_VER', '3.1.4', { newLine: true })
   str += adifField('PROGRAMID', 'Ham2K Portable Logger', { newLine: true })
   str += adifField('PROGRAMVERSION', packageJson.version, { newLine: true })


### PR DESCRIPTION
Includes fetching public bunker list from official source (Google Drive); prefix guessing based on callsign; automatically adding slashes/dashes when inputting bunker to bunker.

There is no specific requirement for log uploading, so for simplicity of output, multiple B2Bs are comma separated in SIG_INFO.

Also transfers handling of "P2P" QSO item icons to extensions.

This also includes extension hook to add comments to ADI header. For UKBOTA in this case, includes details required for entry when submitting activation entry.