### PR TITLE
Enable high accuracy location when getting grid squares

### DIFF
--- a/src/extensions/other/wab/components/WABSquareDialog.jsx
+++ b/src/extensions/other/wab/components/WABSquareDialog.jsx
@@ -64,12 +64,12 @@ export function WABSquareDialog ({ operation, visible, settings, styles, onDialo
     Geolocation.getCurrentPosition(info => {
       const { latitude, longitude } = info.coords
       setWABSquare(locationToWABSquare(latitude, longitude))
-    })
+    }, undefined, { enableHighAccuracy: true })
 
     const watchId = Geolocation.watchPosition(info => {
       const { latitude, longitude } = info.coords
       setWABSquare(locationToWABSquare(latitude, longitude))
-    })
+    }, undefined, { enableHighAccuracy: true })
     return () => {
       Geolocation.clearWatch(watchId)
     }

--- a/src/screens/OperationScreens/OpSettingsTab/components/LocationDialog.js
+++ b/src/screens/OperationScreens/OpSettingsTab/components/LocationDialog.js
@@ -67,14 +67,14 @@ export function LocationDialog ({ operation, visible, settings, styles, onDialog
       setLocationGrid(locationToGrid(latitude, longitude))
     }, error => {
       reportError('location error', error)
-    })
+    }, { enableHighAccuracy: true })
 
     const watchId = Geolocation.watchPosition(info => {
       const { latitude, longitude } = info.coords
       setLocationGrid(locationToGrid(latitude, longitude))
     }, error => {
       reportError('location error', error)
-    })
+    }, { enableHighAccuracy: true })
     return () => {
       Geolocation.clearWatch(watchId)
     }


### PR DESCRIPTION
I've noticed when in locations with poor coarse location due to lack of WiFi or phone signal, that grid squares can be incorrect without use of high accuracy with GPS, etc.

This isn't so much an issue when picking nearby parks/summits/…