### PR TITLE
Only spot first park for POTA

### DIFF
--- a/src/extensions/activities/pota/POTAPostSpot.js
+++ b/src/extensions/activities/pota/POTAPostSpot.js
@@ -15,8 +15,9 @@ export const POTAPostSpot = (operation, vfo, comments) => async (dispatch, getSt
   const call = operation.stationCall || state.settings.operatorCall
 
   const refs = filterRefs(operation, 'potaActivation')
-  const refComment = refs.length > 1 ? `${refs.length}-fer: ${refs.map((x) => (x.ref)).join(' ')}` : ''
-  for (const ref of refs) {
+  if (refs.length > 0) {
+    const ref = refs[0]
+    const refComment = refs.length > 1 ? `${refs.length}-fer: ${refs.map((x) => (x.ref)).join(' ')}` : ''
     try {
       const response = await fetch('https://api.pota.app/spot', {
         method: 'POST',


### PR DESCRIPTION
This changes so only first park is spotted, as seems that multi-spot isn't supported by POTA site due to being one spot per callsign, and therefore last park in the list takes precedence.