### PR TITLE
Add spotting to GMA cluster for ECA/ELA activities

### DIFF
--- a/RELEASE-NOTES.json
+++ b/RELEASE-NOTES.json
@@ -3,7 +3,8 @@
     "changes": [
       "Allow entering incomplete callsigns or references that include a `?`",
       "Various fixes for Spotting control",
-      "Various fixes for Call Notes"
+      "Various fixes for Call Notes",
+      "Add ECA/ELA self-spotting to GMA cluster"
     ]
   },
   "0.7.8": {

--- a/src/extensions/activities/eca/ECAExtension.js
+++ b/src/extensions/activities/eca/ECAExtension.js
@@ -11,6 +11,7 @@ import { findRef, refsToString } from '../../../tools/refTools'
 import { Info } from './ECAInfo'
 import { ecaFindOneByReference, registerECADataFile } from './ECADataFile'
 import { ECAActivityOptions } from './ECAActivityOptions'
+import { ECAPostSpot } from './ECAPostSpot'
 
 const Extension = {
   ...Info,
@@ -31,7 +32,8 @@ export default Extension
 const ActivityHook = {
   ...Info,
   MainExchangePanel: null,
-  Options: ECAActivityOptions
+  Options: ECAActivityOptions,
+  postSpot: ECAPostSpot
 }
 
 const ReferenceHandler = {

--- a/src/extensions/activities/eca/ECAPostSpot.js
+++ b/src/extensions/activities/eca/ECAPostSpot.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { filterRefs } from '../../../tools/refTools'
+import { GMACommonPostSpot } from '../GMACommonPostSpot'
+
+export const ECAPostSpot = (operation, vfo, comments) => async (dispatch, getState) => {
+  const refs = filterRefs(operation, 'ecaActivation')
+  if (refs.length) {
+    dispatch(GMACommonPostSpot(operation, vfo, comments, refs))
+  }
+}

--- a/src/extensions/activities/ela/ELAExtension.js
+++ b/src/extensions/activities/ela/ELAExtension.js
@@ -11,6 +11,7 @@ import { findRef, refsToString } from '../../../tools/refTools'
 import { Info } from './ELAInfo'
 import { elaFindOneByReference, registerELADataFile } from './ELADataFile'
 import { ELAActivityOptions } from './ELAActivityOptions'
+import { ELAPostSpot } from './ELAPostSpot'
 
 const Extension = {
   ...Info,
@@ -31,7 +32,8 @@ export default Extension
 const ActivityHook = {
   ...Info,
   MainExchangePanel: null,
-  Options: ELAActivityOptions
+  Options: ELAActivityOptions,
+  postSpot: ELAPostSpot
 }
 
 const ReferenceHandler = {

--- a/src/extensions/activities/ela/ELAPostSpot.js
+++ b/src/extensions/activities/ela/ELAPostSpot.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { filterRefs } from '../../../tools/refTools'
+import { GMACommonPostSpot } from '../GMACommonPostSpot'
+
+export const ELAPostSpot = (operation, vfo, comments) => async (dispatch, getState) => {
+  const refs = filterRefs(operation, 'elaActivation')
+  if (refs.length) {
+    dispatch(GMACommonPostSpot(operation, vfo, comments, refs))
+  }
+}


### PR DESCRIPTION
This spots at most once per activity type, similar to other activities, posting additional references in comments for n-fer activations, to avoid spamming the cluster.