### PR TITLE
Include seconds in ADIF TIME_ON field

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ rm -rf ios/build
 (cd ios && pod install)
 
 # For all platforms
-```
 watchman watch-del .
 watchman watch-project .
 npm start -- --reset-cache

--- a/src/tools/timeFormats.js
+++ b/src/tools/timeFormats.js
@@ -171,7 +171,7 @@ export function fmtADIFTime (t) {
   t = prepareTimeValue(t)
 
   if (t && t.toISOString) {
-    return t.toISOString().substring(11, 16).replace(/:/g, '')
+    return t.toISOString().substring(11, 19).replace(/:/g, '')
   } else {
     return ''
   }
@@ -188,7 +188,7 @@ export function fmtCabrilloDate (t) {
 }
 
 export function fmtCabrilloTime (t) {
-  return fmtADIFTime(t)
+  return fmtADIFTime(t).substring(0, 4)
 }
 
 export function fmtISODate (t) {

--- a/src/tools/timeFormats.spec.js
+++ b/src/tools/timeFormats.spec.js
@@ -5,7 +5,7 @@
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { prepareTimeValue, fmtShortTimeZulu, fmtTimeZulu, fmtDateZulu, fmtDateTimeZuluDynamic } from './timeFormats'
+import { prepareTimeValue, fmtShortTimeZulu, fmtTimeZulu, fmtDateZulu, fmtDateTimeZuluDynamic, fmtADIFTime, fmtCabrilloTime } from './timeFormats'
 
 describe('prepareTimeValue', () => {
   it('should work', () => {
@@ -54,5 +54,21 @@ describe('fmtDateTimeZuluDynamic', () => {
     expect(fmtDateTimeZuluDynamic('2024-03-10T23:15:00Z', { now, compact: true })).toEqual('Mar 10')
     expect(fmtDateTimeZuluDynamic('2023-05-10T23:15:00Z', { now, compact: true })).toEqual('May 10')
     expect(fmtDateTimeZuluDynamic('2023-02-10T23:15:00Z', { now, compact: true })).toEqual('Feb 2023')
+  })
+})
+
+describe('fmtADIFTime', () => {
+  it('should work', () => {
+    const now = new Date('2024-03-12T12:34:56-0000')
+
+    expect(fmtADIFTime(now.getTime())).toEqual('123456')
+  })
+})
+
+describe('fmtCabrilloTime', () => {
+  it('should work', () => {
+    const now = new Date('2024-03-12T12:34:56-0000')
+
+    expect(fmtCabrilloTime(now.getTime())).toEqual('1234')
   })
 })


### PR DESCRIPTION
This change will add the seconds part of the QSO timestamp when exporting to ADIF.