### PR TITLE
Fix parsing Maidenhead grid square with WWBOTA

### DIFF
--- a/src/extensions/activities/wwbota/WWBOTADataFile.js
+++ b/src/extensions/activities/wwbota/WWBOTADataFile.js
@@ -151,7 +151,7 @@ export async function wwbotaFindAllByLocation (entityPrefix, lat, lon, delta = 1
 
 const OPTIONAL_QUOTED_CSV_ROW_REGEX = /(?<=^|,)(?:(?:"((?:[^"]|"")*)")|([^,]*))(?:,|$)/g
 function parseWWBOTACSVRow (row, options) {
-  const parts = [...row.matchAll(OPTIONAL_QUOTED_CSV_ROW_REGEX)].map(
+  const parts = [...row.trim().matchAll(OPTIONAL_QUOTED_CSV_ROW_REGEX)].map(
     match => match[1] ? match[1].replaceAll('""', '"') : match[2])
   if (options?.headers) {
     const obj = {}


### PR DESCRIPTION
Input file is DOS file which ends each line with `\r\n` which was causing some issues with `\r` being pulled into header name (and grid).

Simple `trim()` on the row first removes this.