### PR TITLE
Add ability to self-spot to SOTAWatch

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -85,6 +85,9 @@ android {
         versionName project.env.get("POLO_BASE_VERSION")
         setProperty("archivesBaseName", applicationId + "-v" + versionCode + "(" + versionName + ")")
         resValue "string", "build_config_package", "com.ham2k.polo"
+        manifestPlaceholders = [
+            appAuthRedirectScheme: 'com.ham2k.polo'
+        ]
     }
     signingConfigs {
         debug {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "proj4": "^2.11",
         "react": "18.2.0",
         "react-native": "0.74.2",
+        "react-native-app-auth": "^7.2.0",
         "react-native-blob-util": "^0.19",
         "react-native-code-push": "^8.2",
         "react-native-config": "^1.5",
@@ -17403,6 +17404,24 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-native-app-auth": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-app-auth/-/react-native-app-auth-7.2.0.tgz",
+      "integrity": "sha512-Vw7td8oXklM0nXcerz/6E8Y6Ww+yDRMSohREllYceUe1570kNI7EIwGhzF3+yKjI4QADi8m/LGb7GdwkDxM4XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "2.2.4",
+        "react-native-base64": "0.0.2"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.63.0"
+      }
+    },
+    "node_modules/react-native-base64": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-base64/-/react-native-base64-0.0.2.tgz",
+      "integrity": "sha512-Fu/J1a2y0X22EJDWqJR2oEa1fpP4gTFjYxk8ElJdt1Yak3HOXmFJ7EohLVHU2DaQkgmKfw8qb7u/48gpzveRbg=="
     },
     "node_modules/react-native-blob-util": {
       "version": "0.19.9",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "proj4": "^2.11",
     "react": "18.2.0",
     "react-native": "0.74.2",
+    "react-native-app-auth": "^7.2.0",
     "react-native-blob-util": "^0.19",
     "react-native-code-push": "^8.2",
     "react-native-config": "^1.5",

--- a/src/extensions/activities/sota/SOTAAccount.jsx
+++ b/src/extensions/activities/sota/SOTAAccount.jsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* eslint-disable react/no-unstable-nested-components */
+import React, { useCallback, useEffect, useState } from 'react'
+import { Button, Dialog, List, Text } from 'react-native-paper'
+import { useDispatch } from 'react-redux'
+import { authorize, logout } from 'react-native-app-auth'
+
+import { setAccountInfo } from '../../../store/settings'
+import { Ham2kListItem } from '../../../screens/components/Ham2kListItem'
+import { Ham2kDialog } from '../../../screens/components/Ham2kDialog'
+import { SOTASSOConfig, useAccountQuery } from './apiSOTA'
+
+export function SOTAAccountSetting ({ settings, styles }) {
+  const [currentDialog, setCurrentDialog] = useState()
+  const accountQueryResults = useAccountQuery(undefined, { skip: !settings?.accounts?.sota?.idToken })
+  return (
+    <React.Fragment>
+      <Ham2kListItem
+        title="SOTA (for SOTAWatch self-spotting)"
+        description={settings?.accounts?.sota?.idToken ? `Logged in as ${accountQueryResults.data?.attributes?.Callsign?.[0] || '…'}` : 'No account'}
+        left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="web" />}
+        onPress={() => setCurrentDialog('accountsSOTA')}
+      />
+      {currentDialog === 'accountsSOTA' && (
+        <AccountsSOTADialog
+          settings={settings}
+          styles={styles}
+          visible={true}
+          onDialogDone={() => setCurrentDialog('')}
+        />
+      )}
+    </React.Fragment>
+  )
+}
+
+export function AccountsSOTADialog ({ visible, settings, styles, onDialogDone }) {
+  const dispatch = useDispatch()
+
+  const [dialogVisible, setDialogVisible] = useState(false)
+
+  useEffect(() => {
+    setDialogVisible(visible)
+  }, [visible])
+
+  const handleClose = useCallback(() => {
+    setDialogVisible(false)
+    onDialogDone && onDialogDone()
+  }, [onDialogDone])
+
+  const handleLogin = useCallback(async () => {
+    try {
+      const result = await authorize(SOTASSOConfig)
+      dispatch(setAccountInfo({
+        sota: {
+          idToken: result.idToken,
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken
+        }
+      }))
+    } catch (error) {
+      console.log(error)
+    }
+  }, [dispatch])
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await logout(
+        { issuer: SOTASSOConfig.issuer },
+        { idToken: settings.accounts.sota.idToken, postLogoutRedirectUrl: SOTASSOConfig.redirectUrl }
+      )
+    } catch (error) {
+      console.log('error', error)
+    }
+    // Assume successful, delete info
+    dispatch(setAccountInfo({ sota: { idToken: undefined } }))
+  }, [dispatch, settings.accounts?.sota?.idToken])
+
+  const accountQueryResults = useAccountQuery(undefined, { skip: !settings?.accounts?.sota?.idToken })
+
+  return (
+    <Ham2kDialog visible={dialogVisible} onDismiss={handleClose}>
+      <Dialog.Title style={{ textAlign: 'center' }}>SOTA Account</Dialog.Title>
+      {!accountQueryResults.isUninitialized ? (
+        <Dialog.Content>
+          {(accountQueryResults.isLoading || accountQueryResults.isSuccess) ? (
+            <Text style={{ textAlign: 'center' }} variant="bodyMedium">Logged in as {accountQueryResults.data?.attributes?.Callsign?.[0] || '…' }</Text>
+          ) : (
+            <Text style={{ textAlign: 'center' }} variant="bodyMedium">Error fetching account details</Text>
+          )}
+          <Button style={{ marginTop: styles.oneSpace * 2 }} mode="contained" onPress={handleLogout}>Logout</Button>
+        </Dialog.Content>
+      ) : (
+        <Dialog.Content>
+          <Text style={{ textAlign: 'center' }} variant="bodyMedium">Connect your SOTA account</Text>
+          <Button style={{ marginTop: styles.oneSpace * 2 }} mode="contained" onPress={handleLogin}>Login</Button>
+        </Dialog.Content>
+      )}
+      <Dialog.Actions>
+        <Button onPress={handleClose}>Close</Button>
+      </Dialog.Actions>
+    </Ham2kDialog>
+  )
+}

--- a/src/extensions/activities/sota/SOTAExtension.js
+++ b/src/extensions/activities/sota/SOTAExtension.js
@@ -13,6 +13,8 @@ import { SOTAActivityOptions } from './SOTAActivityOptions'
 import { registerSOTADataFile, sotaFindOneByReference } from './SOTADataFile'
 import { Info } from './SOTAInfo'
 import { SOTALoggingControl } from './SOTALoggingControl'
+import { SOTAAccountSetting } from './SOTAAccount'
+import { SOTAPostSpot } from './SOTAPostSpot'
 
 const Extension = {
   ...Info,
@@ -21,6 +23,13 @@ const Extension = {
     registerHook('activity', { hook: ActivityHook })
     registerHook(`ref:${Info.huntingType}`, { hook: ReferenceHandler })
     registerHook(`ref:${Info.activationType}`, { hook: ReferenceHandler })
+    registerHook('setting', {
+      hook: {
+        key: 'sota-account',
+        category: 'account',
+        SettingItem: SOTAAccountSetting
+      }
+    })
 
     registerSOTADataFile()
     await dispatch(loadDataFile('sota-all-summits', { noticesInsteadOfFetch: true }))
@@ -41,6 +50,12 @@ const ActivityHook = {
       return [HunterLoggingControl]
     }
   },
+
+  postSpot: SOTAPostSpot,
+  isSpotEnabled: ({ operation, settings }) => {
+    return !!settings?.accounts?.sota?.idToken
+  },
+
   Options: SOTAActivityOptions,
 
   includeControlForQSO: ({ qso, operation }) => {

--- a/src/extensions/activities/sota/SOTAPostSpot.js
+++ b/src/extensions/activities/sota/SOTAPostSpot.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { ADIF_SUBMODES } from '@ham2k/lib-operation-data'
+
+import { filterRefs } from '../../../tools/refTools'
+import { apiSOTA } from './apiSOTA'
+
+const validModes = ['AM', 'CW', 'Data', 'DV', 'FM', 'SSB']
+
+export const SOTAPostSpot = (operation, comments) => async (dispatch, getState) => {
+  const state = getState()
+  const activatorCallsign = operation.stationCall || state.settings.operatorCall
+
+  const refs = filterRefs(operation, 'sotaActivation')
+  for (const ref of refs) { // Should only be one
+    const [associationCode, summitCode] = ref.ref.split('/', 2)
+
+    let mode = operation.mode
+    if (!validModes.includes(mode)) {
+      if (ADIF_SUBMODES.SSB.includes(mode)) {
+        mode = 'SSB'
+      } else if (mode === 'DIGITALVOICE' || ADIF_SUBMODES.DIGITALVOICE.includes(mode)) {
+        mode = 'DV'
+      } else {
+        mode = 'Data' // Reasonable guess
+      }
+    }
+    const spot = {
+      associationCode,
+      summitCode,
+      activatorCallsign,
+      frequency: `${operation.freq / 1000}`, // string
+      mode,
+      comments
+    }
+    // Errors will be logged by apiSOTA
+    const promise = dispatch(apiSOTA.endpoints.spot.initiate(spot))
+    promise.unsubscribe()
+  }
+}

--- a/src/extensions/activities/sota/apiSOTA/apiSOTA.js
+++ b/src/extensions/activities/sota/apiSOTA/apiSOTA.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { refresh } from 'react-native-app-auth'
+
+import packageJson from '../../../../../package.json'
+import { setAccountInfo } from '../../../../store/settings'
+
+/**
+
+  SOTA API v2
+  https://api2.sota.org.uk/docs/index.html
+
+ */
+
+const DEBUG = false
+
+export const SOTASSOConfig = {
+  issuer: 'https://sso.sota.org.uk/auth/realms/SOTA/',
+  clientId: 'sotawatch',
+  redirectUrl: 'com.ham2k.polo://sota',
+  scopes: ['openid']
+}
+
+const baseQueryWithSettings = fetchBaseQuery({
+  baseUrl: 'https://',
+  prepareHeaders: (headers, { getState }) => {
+    headers.set('Accept', 'application/json')
+    headers.set('Content-type', 'application/json')
+    headers.set('Authorization', `bearer ${getState().settings?.accounts?.sota?.accessToken}`)
+    headers.set('User-Agent', `ham2k-polo-${packageJson.version}`)
+    headers.set('id_token', getState().settings?.accounts?.sota?.idToken) // Required by spot API
+    return headers
+  },
+  responseHandler: async (response) => {
+    if (response.status === 200 || response.status === 201) { // 201 for spotting
+      const data = await response.json()
+      if (DEBUG) console.log(`SOTAApi ${response.url} ${response.status}`)
+      if (DEBUG) console.log('-- response', data)
+      return data
+    } else {
+      return {}
+    }
+  }
+})
+
+const baseQueryWithReauth = async (args, api, extraOptions) => {
+  if (DEBUG) console.log('baseQueryWithReauth first call', { args })
+  let result = await baseQueryWithSettings(args, api, extraOptions)
+
+  if (result.error && result.error.status === 401) {
+    // try to get a new access token
+    const refreshToken = api.getState().settings?.accounts?.sota?.refreshToken
+
+    if (DEBUG) console.log('baseQueryWithReauth second call')
+    try {
+      const refreshResult = await refresh(SOTASSOConfig, { refreshToken })
+      if (DEBUG) console.log('New access token received')
+      api.dispatch(setAccountInfo({
+        sota: {
+          accessToken: refreshResult.accessToken,
+          refreshToken: refreshResult.refreshToken
+        }
+      }))
+    } catch (error) {
+      console.log(error)
+      // react-native-app-auth Issue #861
+      if (error.message.includes('Connection error') || error.message.includes('Network error')) {
+        if (DEBUG) console.log('Connection error')
+      } else {
+        console.log('Refresh token failed, logged out...')
+        api.dispatch(setAccountInfo({ sota: { idToken: undefined } }))
+      }
+      // return original result
+      return result
+    }
+
+    if (DEBUG) console.log('baseQueryWithReauth third call')
+    result = await baseQueryWithSettings(args, api, extraOptions)
+  }
+
+  return result
+}
+
+export const apiSOTA = createApi({
+  reducerPath: 'apiSOTA',
+  baseQuery: baseQueryWithReauth,
+  endpoints: builder => ({
+    account: builder.query({
+      query: () => 'sso.sota.org.uk/auth/realms/SOTA/account'
+    }),
+    spot: builder.query({
+      query: (body) => ({
+        url: 'api2.sota.org.uk/api/spots',
+        method: 'POST',
+        body
+      })
+    }),
+    spots: builder.query({
+      query: ({ limit, filter }) => ({
+        url: `api2.sota.org.uk/api/spots/${limit}/${filter ?? 'all'}`
+      })
+    })
+  })
+})
+
+export const { actions } = apiSOTA
+
+export const { endpoints, reducerPath, reducer, middleware, useAccountQuery, useLazySpotQuery } = apiSOTA
+
+export default apiSOTA.reducer

--- a/src/extensions/activities/sota/apiSOTA/index.js
+++ b/src/extensions/activities/sota/apiSOTA/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import reducer from './apiSOTA'
+
+export * from './apiSOTA'
+
+export default reducer

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel.jsx
@@ -32,7 +32,10 @@ export const SecondaryExchangePanel = (props) => {
       edit: editQSOControl
     }
     const activityHooks = findHooks('activity')
-    if (activityHooks.filter((x) => (findRef(operation, x.activationType) && x.postSpot)).length > 0) {
+    if (activityHooks.filter((x) => (
+      findRef(operation, x.activationType) && x.postSpot &&
+      (!x.isSpotEnabled || (x.isSpotEnabled && x.isSpotEnabled({ operation, settings }))))).length > 0
+    ) {
       newControls[spotterControl.key] = spotterControl
     }
     activityHooks.forEach(activity => {

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel/SpotterControl.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel/SpotterControl.jsx
@@ -24,7 +24,7 @@ import { setOperationData } from '../../../../../../store/operations'
 const SECONDS_UNTIL_RESPOT = 30
 
 export function SpotterControlInputs (props) {
-  const { operation, vfo, styles, style, setCurrentSecondaryControl } = props
+  const { operation, vfo, styles, style, settings, setCurrentSecondaryControl } = props
 
   const online = useSelector(selectRuntimeOnline)
 
@@ -81,8 +81,8 @@ export function SpotterControlInputs (props) {
   }, [inProgress, vfo?.freq, operation?.spottedFreq, operation?.spottedAt, operation, now, comments])
 
   const activityHooksWithSpot = useMemo(() =>
-    findHooks('activity').filter((x) => (findRef(operation.refs, x.activationType) && x.postSpot))
-  , [operation.refs])
+    findHooks('activity').filter((x) => (findRef(operation.refs, x.activationType) && x.postSpot && (!x.isSpotEnabled || (x.isSpotEnabled && x.isSpotEnabled({ operation, settings })))))
+  , [operation, settings])
 
   const handleSpotting = useCallback(async () => {
     const status = {}

--- a/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
@@ -13,6 +13,7 @@ import { Linking, ScrollView, useWindowDimensions, View } from 'react-native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 
 import packageJson from '../../../../package.json'
+import { findHooks } from '../../../extensions/registry'
 
 import { selectSettings } from '../../../store/settings'
 import { useThemedStyles } from '../../../styles/tools/useThemedStyles'
@@ -118,6 +119,11 @@ export default function MainSettingsScreen ({ navigation, route }) {
 function MainSettingsOptions ({ settings, styles, navigation }) {
   const [currentDialog, setCurrentDialog] = useState()
 
+  const accountSettingHooks = useMemo(() => {
+    const hooks = findHooks('setting').filter(hook => hook.category === 'account' && hook.SettingItem)
+    return hooks
+  }, [])
+
   return (
     <ScrollView style={{ flex: 1 }}>
       <Ham2kListSection>
@@ -202,6 +208,9 @@ function MainSettingsOptions ({ settings, styles, navigation }) {
             onDialogDone={() => setCurrentDialog('')}
           />
         )}
+        {accountSettingHooks.map((hook) => (
+          <hook.SettingItem key={hook.key} settings={settings} styles={styles} />
+        ))}
       </Ham2kListSection>
 
       <Ham2kListSection>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -21,6 +21,7 @@ import stationReducer from './station'
 import timeReducer from './time'
 import { reducer as apiQRZReducer, middleware as apiQRZMiddleware } from './apiQRZ'
 import { reducer as apiPOTAReducer, middleware as apiPOTAMiddleware } from './apiPOTA'
+import { reducer as apiSOTAReducer, middleware as apiSOTAMiddleware } from '../extensions/activities/sota/apiSOTA'
 import dataFilesReducer from './dataFiles'
 
 // Redux Toolkit uses Immer, which freezes state by default.
@@ -41,7 +42,8 @@ const rootReducer = combineReducers({
   time: timeReducer,
   dataFiles: dataFilesReducer,
   apiQRZ: apiQRZReducer,
-  apiPOTA: apiPOTAReducer
+  apiPOTA: apiPOTAReducer,
+  apiSOTA: apiSOTAReducer
 })
 
 const persistConfig = {
@@ -90,6 +92,7 @@ export const store = configureStore({
 
     middlewares.push(apiQRZMiddleware)
     middlewares.push(apiPOTAMiddleware)
+    middlewares.push(apiSOTAMiddleware)
 
     return middlewares
   },


### PR DESCRIPTION
This includes addition of connecting to SOTA to enable self-spotting for SOTA activations.

Requires new dependency react-native-app-auth.

This is work in progress, as supports Android only currently.