### PR TITLE
Only explicitly clear SOTA auth token on invalid_grant error

### DIFF
--- a/src/store/apiSOTA/apiSOTA.js
+++ b/src/store/apiSOTA/apiSOTA.js
@@ -88,9 +88,12 @@ const baseQueryWithReauth = async (args, api, extraOptions) => {
       // react-native-app-auth Issue #861
       if (error.message.includes('Connection error') || error.message.includes('Network error')) {
         if (DEBUG) console.log('Connection error')
-      } else {
+      } else if (error.code === 'invalid_grant') {
         console.log('Refresh token failed, logged out...')
         api.dispatch(setAccountInfo({ sota: { idToken: undefined } }))
+      } else {
+        // Let's not be too hasty clearing token
+        console.log('Unknown error refreshing token', error.code)
       }
       // return original result
       return result


### PR DESCRIPTION
SOTA API seems overly keen to assume account is logged out.

The fact that checking error message strings for connection errors isn't very robust, and more explicit check is probably required.

This adds a check that only flags account as logged out when an invalid grant error is returned. See below

> invalid_grant
>       The provided authorization grant (e.g., authorization
>       code, resource owner credentials) or refresh token is
>       invalid, expired, revoked, does not match the redirection
>       URI used in the authorization request, or was issued to
>       another client.