### PR TITLE
Order scores by value for messages when logging

### DIFF
--- a/src/extensions/activities/gma/GMAExtension.js
+++ b/src/extensions/activities/gma/GMAExtension.js
@@ -56,7 +56,9 @@ const ActivityHook = {
     let label = opRef ? Info.shortNameDoubleContact : Info.shortName
     if (findRef(qso, Info.huntingType)) label = `✓ ${label}`
     return label
-  }
+  },
+
+  generalHuntingType: ({ operation, settings }) => Info.huntingType
 }
 
 const HunterLoggingControl = {

--- a/src/extensions/activities/siota/SiOTAExtension.js
+++ b/src/extensions/activities/siota/SiOTAExtension.js
@@ -54,7 +54,9 @@ const ActivityHook = {
     let label = opRef ? Info.shortNameDoubleContact : Info.shortName
     if (findRef(qso, Info.huntingType)) label = `✓ ${label}`
     return label
-  }
+  },
+
+  generalHuntingType: ({ operation, settings }) => Info.huntingType
 }
 
 const HunterLoggingControl = {

--- a/src/extensions/activities/wwbota/WWBOTAExtension.js
+++ b/src/extensions/activities/wwbota/WWBOTAExtension.js
@@ -56,7 +56,9 @@ const ActivityHook = {
     let label = opRef ? Info.shortNameDoubleContact : Info.shortName
     if (findRef(qso, Info.huntingType)) label = `✓ ${label}`
     return label
-  }
+  },
+
+  generalHuntingType: ({ operation, settings }) => Info.huntingType
 }
 
 const HunterLoggingControl = {

--- a/src/extensions/activities/wwff/WWFFExtension.js
+++ b/src/extensions/activities/wwff/WWFFExtension.js
@@ -58,7 +58,9 @@ const ActivityHook = {
     let label = opRef ? Info.shortNameDoubleContact : Info.shortName
     if (findRef(qso, Info.huntingType)) label = `✓ ${label}`
     return label
-  }
+  },
+
+  generalHuntingType: ({ operation, settings }) => Info.huntingType
 }
 
 const SpotsHook = {

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/CallInfo.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/CallInfo.jsx
@@ -180,7 +180,8 @@ export function CallInfo ({ qso, qsos, operation, style, themeColor, setQSO, set
 
   const [historyMessage, historyLevel] = useMemo(() => {
     if (scoreInfo?.length > 0) {
-      const [message, level] = scoreInfo.map(score => {
+      // Order by value, as those that provide points/QSOs/etc. more important
+      const [message, level] = scoreInfo.sort((a, b) => (b.value ?? 0) - (a.value ?? 0)).map(score => {
         if (score?.notices && score?.notices[0]) return [MESSAGES_FOR_SCORING[`${score.type}.${score?.notices[0]}`] ?? MESSAGES_FOR_SCORING[score?.notices[0]] ?? score?.notices[0], 'notice']
         if (score?.alerts && score?.alerts[0]) return [MESSAGES_FOR_SCORING[`${score.type}.${score?.alerts[0]}`] ?? MESSAGES_FOR_SCORING[score?.alerts[0]] ?? score?.alerts[0], 'alert']
         return []


### PR DESCRIPTION
Order is such that those that provide "value" come first, as this means new references for example, come before 0 point dupe messages for other activities.