### PR TITLE
Add "GMA" to GMA export filename

### DIFF
--- a/src/extensions/activities/gma/GMAExtension.js
+++ b/src/extensions/activities/gma/GMAExtension.js
@@ -127,7 +127,7 @@ const ReferenceHandler = {
       return [{
         format: 'adif',
         common: { refs: [ref] },
-        nameTemplate: settings.useCompactFileNames ? '{call}@{ref}-{compactDate}' : '{date} {call} at {ref}',
+        nameTemplate: settings.useCompactFileNames ? '{call}@GMA-{ref}-{compactDate}' : '{date} {call} at GMA {ref}',
         titleTemplate: `{call}: ${Info.shortName} at ${[ref.ref, ref.name].filter(x => x).join(' - ')} on {date}`
       }]
     }


### PR DESCRIPTION
SOTA summits are also valid for GMA activity, so can have duplicate filename with SOTA, producing only one log.

Whilst you could have just a SOTA log, as GMA accepts them, this would not enable GMA S2S where other summit is GMA and own in SOTA. So two logs are required.