### PR TITLE
Use offline access token and handle 500 code for SOTA API

### DIFF
--- a/src/store/apis/apiSOTA/apiSOTA.js
+++ b/src/store/apis/apiSOTA/apiSOTA.js
@@ -25,7 +25,7 @@ export const SOTASSOConfig = {
   issuer: 'https://sso.sota.org.uk/auth/realms/SOTA/',
   clientId: 'sotawatch',
   redirectUrl: 'com.ham2k.polo://sota',
-  scopes: ['openid']
+  scopes: ['openid', 'offline_access']
 }
 
 const baseQueryWithSettings = fetchBaseQuery({

--- a/src/store/apis/apiSOTA/apiSOTA.js
+++ b/src/store/apis/apiSOTA/apiSOTA.js
@@ -60,12 +60,8 @@ const baseQueryWithReauth = async (args, api, extraOptions) => {
 
   let getNewToken = false
   if (result.error && result.meta.request.headers.has('id_Token')) {
-    if (result.error.status === 401) {
+    if (result.error.status === 401 || result.error.status === 500) {
       getNewToken = true
-    } else if (result.error.status === 500) {
-      if (result.data?.body?.indexOf('authentication') >= 0) {
-        getNewToken = true
-      }
     }
   }
 


### PR DESCRIPTION
This avoids issues with stability of refresh tokens, as token should no longer expire (but still needs to be refreshed once every 30days to maintain it).