### PR TITLE
Change SOTA spots frequency to kHz to fix spots ordering

### DIFF
--- a/src/extensions/activities/sota/SOTAExtension.js
+++ b/src/extensions/activities/sota/SOTAExtension.js
@@ -94,8 +94,8 @@ const SpotsHook = {
     const qsos = spots.filter(x => (x?.type ?? 'NORMAL') === 'NORMAL').map(spot => {
       const qso = {
         their: { call: spot.activatorCallsign },
-        freq: spot.frequency,
-        band: spot.frequency ? bandForFrequency(spot.frequency) : spot.band,
+        freq: spot.frequency * 1000,
+        band: spot.frequency ? bandForFrequency(spot.frequency * 1000) : 'other',
         mode: spot.mode.toUpperCase(),
         refs: [{
           ref: spot.summitCode,


### PR DESCRIPTION
Whilst PoLo was clever enough to realise frequency was in MHz, the ordering of spots page was broken. This changes freq to be in kHz for spots (like POTA and WWFF) to fix ordering.