### PR TITLE
Merge spots from multiple clusters

### DIFF
--- a/src/screens/OperationScreens/OpSpotsTab/components/SpotItem.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/SpotItem.jsx
@@ -72,15 +72,16 @@ const SpotItem = React.memo(function QSOItem ({ spot, onPress, styles, extendedW
         <View style={styles.doubleRowInnerRow}>
           <Text style={[styles.fields.band, commonStyle, bandStyle]}>{spot.band}</Text>
           <Text style={[styles.fields.mode, commonStyle, modeStyle]}>{spot.mode}</Text>
-          {spot.spot?.icon && (
-            <View style={[styles.fields.icon, commonStyle, refStyle]}>
+          {spot.spots.filter(s => s?.icon).map(subSpot => (
+            <View key={subSpot.source} style={[styles.fields.icon, commonStyle, refStyle]}>
               <Icon
-                source={spot.spot?.icon}
+                key={subSpot.source}
+                source={subSpot.icon}
                 size={styles.oneSpace * 2.3}
-                color={refStyle?.color || commonStyle?.color}
+                color={(subSpot?.type === 'scoring' && refStyle?.color) || commonStyle?.color}
               />
             </View>
-          )}
+          ))}
           <Text style={[styles.fields.label, commonStyle, refStyle]} numberOfLines={1} ellipsizeMode="tail">
             {spot.spot.label}
           </Text>


### PR DESCRIPTION
This merges spots from multiple cluster where the callsign is the same, frequency is within 0.5kHz and time between spots less than 30mins. The most recent spot is primary, with additional refs and spot details added to it. Non-mergeable spots will be show separately as before

This also tweaks scoring of spots slightly, such that new refs are still highlight appropriately, for example operator activating 2 summits, but in same POTA, will show spot with new summit and SOTA icon highlight in green.

When logging QSO, all references are then saved as expected.

Merged example:
![Screenshot From 2024-11-01 08-49-50](https://github.com/user-attachments/assets/bbb9f0e8-7937-420f-a3c2-a38e6efc35c7)
Worked all references:
![Screenshot From 2024-11-01 08-51-03](https://github.com/user-attachments/assets/a9b65efe-51f5-41fd-876d-01784961a3c9)
New ref for one activity type, with new reference name taking preference:
![Screenshot From 2024-11-01 08-50-32](https://github.com/user-attachments/assets/e2c43bb6-126d-4c75-8f63-b9b6479d0b03)
