### PR TITLE
Add HamQTH lookup

### DIFF
--- a/RELEASE-NOTES.json
+++ b/RELEASE-NOTES.json
@@ -2,7 +2,8 @@
   "24.11.99-pre0": {
     "name": "December '24 (Pre 0)",
     "changes": [
-      "Fixed problems with external keyboards on Android"
+      "Fixed problems with external keyboards on Android",
+      "Add HamQTH callsign lookup"
     ]
   },
   "24.11.2": {

--- a/src/extensions/data/hamqth/HamQTHAccount.jsx
+++ b/src/extensions/data/hamqth/HamQTHAccount.jsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/* eslint-disable react/no-unstable-nested-components */
+import React, { useCallback, useEffect, useState } from 'react'
+import { Button, Dialog, List, Text } from 'react-native-paper'
+import { useDispatch } from 'react-redux'
+import { setAccountInfo } from '../../../store/settings'
+import ThemedTextInput from '../../../screens/components/ThemedTextInput'
+import CallsignInput from '../../../screens/components/CallsignInput'
+import { Ham2kListItem } from '../../../screens/components/Ham2kListItem'
+import { Ham2kDialog } from '../../../screens/components/Ham2kDialog'
+
+export function HamQTHAccountSetting ({ settings, styles }) {
+  const [currentDialog, setCurrentDialog] = useState()
+  return (
+    <React.Fragment>
+      <Ham2kListItem
+        title="HamQTH (for callsign lookups)"
+        description={settings?.accounts?.hamqth ? `Login: ${settings.accounts.hamqth.login}` : 'No account'}
+        left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="web" />}
+        onPress={() => setCurrentDialog('accountsHamQTH')}
+      />
+      {currentDialog === 'accountsHamQTH' && (
+        <AccountsHamQTHDialog
+          settings={settings}
+          styles={styles}
+          visible={true}
+          onDialogDone={() => setCurrentDialog('')}
+        />
+      )}
+    </React.Fragment>
+  )
+}
+
+function AccountsHamQTHDialog ({ visible, settings, styles, onDialogDone }) {
+  const dispatch = useDispatch()
+
+  const [dialogVisible, setDialogVisible] = useState(false)
+
+  const [login, setLogin] = useState('')
+  const [password, setPassword] = useState('')
+
+  useEffect(() => {
+    setDialogVisible(visible)
+  }, [visible])
+
+  useEffect(() => {
+    setLogin(settings?.accounts?.hamqth?.login || '')
+    setPassword(settings?.accounts?.hamqth?.password || '')
+  }, [settings])
+
+  const onChangeLogin = useCallback((text) => {
+    setLogin(text)
+  }, [setLogin])
+  const onChangePassword = useCallback((text) => {
+    setPassword(text)
+  }, [setPassword])
+
+  const handleAccept = useCallback(() => {
+    dispatch(setAccountInfo({ hamqth: { login, password } }))
+    setDialogVisible(false)
+    onDialogDone && onDialogDone()
+  }, [login, password, dispatch, onDialogDone])
+
+  const handleCancel = useCallback(() => {
+    setLogin(settings?.accounts?.hamqth?.login || '')
+    setPassword(settings?.accounts?.hamqth?.password || '')
+    setDialogVisible(false)
+    onDialogDone && onDialogDone()
+  }, [settings, onDialogDone])
+
+  return (
+    <Ham2kDialog visible={dialogVisible} onDismiss={handleCancel}>
+      <Dialog.Title style={{ textAlign: 'center' }}>HamQTH Account</Dialog.Title>
+      <Dialog.Content>
+        <Text variant="bodyMedium">Please enter the details for your HamQTH account:</Text>
+        <CallsignInput
+          style={[styles.input, { marginTop: styles.oneSpace }]}
+          value={login}
+          label="Callsign"
+          placeholder="your account callsign"
+          onChangeText={onChangeLogin}
+        />
+        <ThemedTextInput
+          style={[styles.input, { marginTop: styles.oneSpace }]}
+          value={password}
+          label="Password"
+          autoComplete="current-password"
+          keyboardType="default"
+          textContentType="password"
+          secureTextEntry={true}
+          autoCapitalize={'none'}
+          placeholder="your password"
+          onChangeText={onChangePassword}
+        />
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button onPress={handleCancel}>Cancel</Button>
+        <Button onPress={handleAccept}>Ok</Button>
+      </Dialog.Actions>
+    </Ham2kDialog>
+  )
+}

--- a/src/extensions/data/hamqth/HamQTHExtension.js
+++ b/src/extensions/data/hamqth/HamQTHExtension.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { apiHamQTH } from '../../../store/apis/apiHamQTH'
+import { HamQTHAccountSetting } from './HamQTHAccount'
+
+export const Info = {
+  key: 'hamqth',
+  icon: 'account-search',
+  name: 'HamQTH.com Callsign Lookups',
+  description: 'Requires free account for lookups',
+  shortName: 'HamQTH',
+  infoURL: 'https://www.hamqth.com/'
+}
+
+const Extension = {
+  ...Info,
+  category: 'lookup',
+  onActivation: ({ registerHook }) => {
+    registerHook('lookup', { hook: LookupHook, priority: 50 })
+    registerHook('setting', {
+      hook: {
+        key: 'hamqth-account',
+        category: 'account',
+        SettingItem: HamQTHAccountSetting
+      }
+    })
+  }
+}
+export default Extension
+
+const LookupHook = {
+  ...Info,
+  shouldSkipLookup: ({ online, lookedUp }) => {
+    return !online || (lookedUp.name && lookedUp.grid)
+  },
+  lookupCallWithDispatch: async (callInfo, { settings, online, dispatch }) => {
+    if (online && settings?.accounts?.hamqth?.login && settings?.accounts?.hamqth?.password && callInfo?.baseCall?.length > 2) {
+      const promise = await dispatch(apiHamQTH.endpoints.lookupCall.initiate({ call: callInfo.call }))
+      await Promise.all(dispatch(apiHamQTH.util.getRunningQueriesThunk()))
+      const lookup = await dispatch((_dispatch, getState) => apiHamQTH.endpoints.lookupCall.select({ call: callInfo.call })(getState()))
+      promise.unsubscribe && promise.unsubscribe()
+
+      if (lookup?.data?.call) {
+        return { ...lookup.data, source: 'hamqth' }
+      }
+    }
+    return {}
+  }
+}

--- a/src/extensions/loadExtensions.js
+++ b/src/extensions/loadExtensions.js
@@ -26,6 +26,7 @@ import CallNotesExtension from './data/call-notes/CallNotesExtension'
 import CallHistoryExtension from './data/call-history/CallHistoryExtension'
 import QRZExtension from './data/qrz/QRZExtension'
 import HamDBExtension from './data/hamdb/HamDBExtension'
+import HamQTHExtension from './data/hamqth/HamQTHExtension'
 import SatellitesExtension from './activities/satellites/SatellitesExtension'
 
 import NYQPExtension from './contests/nyqp/NYQPExtension'
@@ -68,6 +69,7 @@ const loadExtensions = () => async (dispatch, getState) => {
 
   registerExtension(QRZExtension)
   registerExtension(HamDBExtension)
+  registerExtension(HamQTHExtension)
 
   registerExtension(SatellitesExtension)
 

--- a/src/screens/OperationScreens/OpInfoTab/components/useCallLookup.js
+++ b/src/screens/OperationScreens/OpInfoTab/components/useCallLookup.js
@@ -121,7 +121,7 @@ async function _lookupCall (theirInfo, { online, settings, dispatch, skipLookup 
         }
         if (data) {
           lookups[hook.key] = data
-          Object.keys(data).forEach(key => { lookedUp[key] = true })
+          Object.keys(filterFalsyNotZero(data)).forEach(key => { lookedUp[key] = true })
         }
       }
     }
@@ -151,11 +151,11 @@ function _mergeData ({ theirInfo, lookups, refs }) {
   let mergedLookup = {}
   const newGuess = { ...theirInfo }
 
-  for (const key in lookups) {
+  for (const key in lookups) { // High to low priority
     if (lookups[key].call === theirInfo.call || lookups[key].call === theirInfo.baseCall) {
       mergedLookup = {
+        ...filterFalsyNotZero(lookups[key]),
         ...mergedLookup,
-        ...lookups[key],
         notes: [...mergedLookup.notes ?? [], ...lookups[key].notes ?? []],
         history: [...mergedLookup.history ?? [], ...lookups[key].history ?? []]
       }
@@ -207,4 +207,13 @@ function _mergeData ({ theirInfo, lookups, refs }) {
   }
 
   return { guess: newGuess, lookup: mergedLookup }
+}
+
+function filterFalsyNotZero (obj) {
+  return Object.keys(obj).reduce((acc, key) => {
+    if (obj[key] || obj[key] === 0) {
+      acc[key] = obj[key]
+    }
+    return acc
+  }, {})
 }

--- a/src/screens/OperationScreens/OpInfoTab/components/useCallLookup.js
+++ b/src/screens/OperationScreens/OpInfoTab/components/useCallLookup.js
@@ -154,13 +154,14 @@ function _mergeData ({ theirInfo, lookups, refs }) {
   for (const key in lookups) { // High to low priority
     if (lookups[key].call === theirInfo.call || lookups[key].call === theirInfo.baseCall) {
       mergedLookup = {
+        sources: [],
         ...filterFalsyNotZero(lookups[key]),
         ...mergedLookup,
         notes: [...mergedLookup.notes ?? [], ...lookups[key].notes ?? []],
         history: [...mergedLookup.history ?? [], ...lookups[key].history ?? []]
       }
       if (lookups[key].source) {
-        mergedLookup.sources = (mergedLookup.sources || []) + [lookups[key].source]
+        mergedLookup.sources.push(lookups[key].source)
       }
     }
   }

--- a/src/store/apis/apiHamQTH/apiHamQTH.js
+++ b/src/store/apis/apiHamQTH/apiHamQTH.js
@@ -1,0 +1,187 @@
+/*
+/
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { XMLParser } from 'fast-xml-parser'
+
+import packageJson from '../../../../package.json'
+import { capitalizeString } from '../../../tools/capitalizeString'
+
+/**
+
+  HamQTH.com XML API
+  https://www.hamqth.com/developers.php
+
+ */
+
+const DEBUG = false
+
+const BASE_URL = 'https://www.hamqth.com/'
+
+const apiState = {}
+
+function defaultParams (api) {
+  const session = apiState.session
+  return {
+    id: session,
+    prg: `ham2k-polo-${packageJson.version}`
+  }
+}
+
+const baseQueryWithSettings = fetchBaseQuery({
+  baseUrl: `${BASE_URL}/xml.php`,
+  prepareHeaders: (headers, { getState, endpoint }) => {
+    headers.set('User-Agent', `ham2k-polo-${packageJson.version}`)
+  },
+  responseHandler: async (response) => {
+    if (response.status === 200) {
+      const body = await response.text()
+      const parser = new XMLParser()
+      const xml = parser.parse(body)
+      if (DEBUG) console.log(`HamQTHApi ${response.url} ${response.status}`)
+      if (DEBUG) console.log('-- url', response.url)
+      if (DEBUG) console.log('-- response', xml)
+      return xml
+    } else {
+      return {}
+    }
+  }
+})
+
+const baseQueryWithReauth = async (args, api, extraOptions) => {
+  if (DEBUG) console.log('baseQueryWithReauth first call', { args })
+  let result = await baseQueryWithSettings(args, api, extraOptions)
+
+  if ((result.error && result.error.status === 401) ||
+    result.data?.HamQTH?.session?.error?.startsWith('Username or password missing') ||
+    result.data?.HamQTH?.session?.error?.startsWith('Session does not exist or expired') ||
+    result.data?.HamQTH?.session?.error?.startsWith('Wrong user name or password')
+  ) {
+    apiState.session = undefined
+    // try to get a new session key
+    const { login, password } = api.getState().settings?.accounts?.hamqth ?? {}
+    if (DEBUG) console.log('baseQueryWithReauth second call')
+    result = await baseQueryWithSettings({
+      url: '',
+      params: {
+        ...defaultParams(api),
+        u: login,
+        p: password
+      }
+    }, api, extraOptions)
+
+    if (result.data?.HamQTH?.session?.error) return { error: result.data?.HamQTH?.session?.error, meta: result.meta }
+
+    const session = result.data?.HamQTH?.session?.session_id
+    if (session) {
+      if (DEBUG) console.log('New Session', session)
+      apiState.session = session
+      args.params = { ...args.params, ...defaultParams(api) } // Refresh params to include new session info
+
+      if (DEBUG) console.log('baseQueryWithReauth third call')
+      result = await baseQueryWithSettings(args, api, extraOptions)
+    } else {
+      apiState.session = undefined
+      return { error: 'Unexpected error logging into HamQTH' }
+    }
+  }
+  return result
+}
+
+export const apiHamQTH = createApi({
+  reducerPath: 'apiHamQTH',
+  baseQuery: baseQueryWithReauth,
+  endpoints: builder => ({
+
+    // Lookup a callsign
+    //   https://www.hamqth.com/xml.php?id=SESSIONKEY&callsign=xx2xxx&prg=YOUR_PROGRAM_NAME
+
+    lookupCall: builder.query({
+      keepUnusedDataFor: 60 * 60 * 12, // 12 hours
+      queryFn: async (args, api, extraOptions, baseQuery) => {
+        const { call } = args
+        if (!call || call.length < 3) return { data: {} }
+
+        const response = await baseQuery({
+          url: '',
+          params: {
+            ...defaultParams(api),
+            callsign: call
+          }
+        }, api, extraOptions)
+
+        if (response.data) {
+          const xml = response.data
+          const error = xml?.HamQTH?.session?.error
+
+          if (error) {
+            if (error.startsWith('Callsign not found')) {
+              return { error: `${call} not found`, data: undefined }
+            } else {
+              return { ...response, error, data: undefined }
+            }
+          } else {
+            const callsignInfo = xml?.HamQTH?.search || {}
+
+            // Image always returned...lets drop default images
+            let image = castString(callsignInfo.picture)
+            if (image.startsWith('https://www.hamqth.com/images/default/')) {
+              image = undefined
+            }
+
+            return {
+              ...response,
+              error: undefined,
+              data: {
+                name: capitalizeString(callsignInfo.nick, { content: 'name', force: false }),
+                call: castString(callsignInfo.callsign).toUpperCase(),
+                gmtOffset: castNumber(callsignInfo.utc_offset),
+                city: capitalizeString(callsignInfo.qth, { content: 'address', force: false }),
+                state: castString(callsignInfo.us_state),
+                country: capitalizeString(callsignInfo.country, { force: false }),
+                postal: castString(callsignInfo.adr_zip),
+                county: capitalizeString(callsignInfo.us_county, { force: false }),
+                grid: castString(callsignInfo.grid),
+                cqZone: castNumber(callsignInfo.CQ),
+                ituZone: castNumber(callsignInfo.itu),
+                dxccCode: castNumber(callsignInfo.adif),
+                lat: castNumber(callsignInfo.latitude),
+                lon: castNumber(callsignInfo.longitude),
+                image
+              },
+              meta: response.meta
+            }
+          }
+        } else {
+          return response
+        }
+      }
+    })
+  })
+})
+
+function castString (value) {
+  if (value === undefined || value === null) return ''
+  return String(value)
+}
+
+function castNumber (value) {
+  if (value === undefined || value === null) return 0
+  const number = Number(value)
+  if (isNaN(number)) return null
+  return number
+}
+
+export const { actions } = apiHamQTH
+
+export const { useLookupCallQuery } = apiHamQTH
+
+export const { endpoints, reducerPath, reducer, middleware } = apiHamQTH
+
+export default apiHamQTH.reducer

--- a/src/store/apis/apiHamQTH/apiHamQTH.js
+++ b/src/store/apis/apiHamQTH/apiHamQTH.js
@@ -172,7 +172,7 @@ function castString (value) {
 }
 
 function castNumber (value) {
-  if (value === undefined || value === null) return 0
+  if (value === undefined || value === null) return null
   const number = Number(value)
   if (isNaN(number)) return null
   return number

--- a/src/store/apis/apiHamQTH/index.js
+++ b/src/store/apis/apiHamQTH/index.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import reducer from './apiHamQTH'
+
+export * from './apiHamQTH'
+
+export default reducer

--- a/src/store/apis/apiQRZ/apiQRZ.js
+++ b/src/store/apis/apiQRZ/apiQRZ.js
@@ -173,7 +173,7 @@ function castString (value) {
 }
 
 function castNumber (value) {
-  if (value === undefined || value === null) return 0
+  if (value === undefined || value === null) return null
   const number = Number(value)
   if (isNaN(number)) return null
   return number

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -20,6 +20,7 @@ import qsosReducer from './qsos'
 import stationReducer from './station'
 import timeReducer from './time'
 import { reducer as apiQRZReducer, middleware as apiQRZMiddleware } from './apis/apiQRZ'
+import { reducer as apiHamQTHReducer, middleware as apiHamQTHMiddleware } from './apis/apiHamQTH'
 import { reducer as apiPOTAReducer, middleware as apiPOTAMiddleware } from './apis/apiPOTA'
 import { reducer as apiSOTAReducer, middleware as apiSOTAMiddleware } from './apis/apiSOTA'
 import { reducer as apiGMAReducer, middleware as apiGMAMiddleware } from './apis/apiGMA'
@@ -43,6 +44,7 @@ const rootReducer = combineReducers({
   time: timeReducer,
   dataFiles: dataFilesReducer,
   apiQRZ: apiQRZReducer,
+  apiHamQTH: apiHamQTHReducer,
   apiPOTA: apiPOTAReducer,
   apiSOTA: apiSOTAReducer,
   apiGMA: apiGMAReducer
@@ -93,6 +95,7 @@ export const store = configureStore({
     })
 
     middlewares.push(apiQRZMiddleware)
+    middlewares.push(apiHamQTHMiddleware)
     middlewares.push(apiPOTAMiddleware)
     middlewares.push(apiSOTAMiddleware)
     middlewares.push(apiGMAMiddleware)


### PR DESCRIPTION
This adds HamQTH lookup for call data. This is a free service but requires login credentials.

This change includes a new account setting for entering log in details, and new API for HamQTH, which is very similar to QRZ.com API.

As part of this change there are also improved handling of lookup merging to ensure that when multiple lookups are done, that information is merged in priority order, but also stops high priority empty data taking preference of lower priority but present data.

This also resolved an issue with high priority data stopping lookup from other services, when that data was empty string e.g. grid from free QRZ.com lookup.