### PR TITLE
Refresh account settings hooks on settings change

### DIFF
--- a/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
@@ -124,7 +124,7 @@ function MainSettingsOptions ({ settings, styles, navigation }) {
   const accountSettingHooks = useMemo(() => {
     const hooks = findHooks('setting').filter(hook => hook.category === 'account' && hook.SettingItem)
     return hooks
-  }, [])
+  }, [settings]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <ScrollView style={{ flex: 1 }}>


### PR DESCRIPTION
This resolves issue with for example HamQTH or SOTA account settings not appearing if toggling on for the first time.

Reference https://forums.ham2k.com/t/minor-bug-hamqth-account-field-not-shown-after-activating/346