### PR TITLE
Handle SOTAWatch 403 error

### DIFF
--- a/src/store/apis/apiSOTA/apiSOTA.js
+++ b/src/store/apis/apiSOTA/apiSOTA.js
@@ -65,7 +65,7 @@ const baseQueryWithReauth = async (args, api, extraOptions) => {
 
   let getNewToken = false
   if (result.error && result.meta.request.headers.has('id_Token')) {
-    if (result.error.status === 401 || result.error.status === 500) {
+    if (result.error.status === 401 || result.error.status === 403 || result.error.status === 500) {
       getNewToken = true
     }
   }


### PR DESCRIPTION
SOTAWatch now returns a 403 response with new API, not 500, when token has expired.

Reference https://forums.ham2k.com/t/bug-autoconnect-reconnect-to-send-sota-spot/347