### PR TITLE
Fix grid missing in WWBOTA

### DIFF
--- a/src/extensions/activities/wwbota/WWBOTADataFile.js
+++ b/src/extensions/activities/wwbota/WWBOTADataFile.js
@@ -57,6 +57,8 @@ export function registerWWBOTADataFile () {
                     const row = parseWWBOTACSVRow(line, { headers })
                     const ref = row.Reference
                     if (ref) {
+                      // Use Locator if Maidenhead field not present
+                      row.Maidenhead ||= row.Locator
                       row.Maidenhead &&= row.Maidenhead.replace(/[A-Z]{2}$/, x => x.toLowerCase())
                       const entityPrefix = ref.split('-')[0].split('/')[1]
                       const data = {


### PR DESCRIPTION
Field renamed from Maidenhead to Locator in WWBOTA reference file. Not sure if intentional change or not, so try to get new field only if old field not present