### PR TITLE
Use station call as fallback for subtitle

### DIFF
--- a/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
@@ -45,7 +45,7 @@ export default function OperationDataScreen (props) {
     let options = { title: 'Operation Data' }
     if (operation?.stationCall) {
       options = {
-        subTitle: buildTitleForOperation({ operatorCall: operation.local?.operatorCall, stationCall: operation.stationCallPlus, title: operation.title, userTitle: operation.userTitle })
+        subTitle: buildTitleForOperation({ operatorCall: operation.local?.operatorCall, stationCall: operation.stationCallPlus || operation.stationCall, title: operation.title, userTitle: operation.userTitle })
       }
     } else {
       options = { subTitle: 'New Operation' }


### PR DESCRIPTION
Show station callsign when exporting logs.

| Before | After |
|-|-|
| ![image](https://github.com/user-attachments/assets/b6307388-4429-4b6d-a877-9a8ad7d68b56) | ![image](https://github.com/user-attachments/assets/cab4b98c-d1a3-4d24-8d83-3bc217641ab8) |