### PR TITLE
Add deduping on ADIF import for operations

### DIFF
--- a/src/extensions/scoring/DefaultScoringHandler.js
+++ b/src/extensions/scoring/DefaultScoringHandler.js
@@ -10,7 +10,7 @@ export const DefaultScoringHandler = {
   scoringForQSO: ({ qso, qsos, operation, ref }) => {
     const { band, mode, uuid, startAtMillis } = qso
 
-    const nearDupes = (qsos || []).filter(q => !q.deleted && (startAtMillis ? q.startAtMillis < startAtMillis : true) && q.their.call === qso.their.call && q.uuid !== uuid)
+    const nearDupes = (qsos || []).filter(q => !q.deleted && (startAtMillis ? q.startAtMillis <= startAtMillis : true) && q.their.call === qso.their.call && q.uuid !== uuid)
 
     if (nearDupes.length === 0) {
       return { count: 1, type: 'defaultOperation' }

--- a/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
@@ -109,9 +109,10 @@ export default function OperationDataScreen (props) {
   const handleImportADIF = useCallback(() => {
     DocumentPicker.pickSingle({ mode: 'import', copyTo: 'cachesDirectory' }).then(async (file) => {
       const filename = decodeURIComponent(file.fileCopyUri.replace('file://', ''))
-      const count = await dispatch(importADIFIntoOperation(filename, operation))
+      const { adifCount, importCount } = await dispatch(importADIFIntoOperation(filename, operation, qsos))
       trackEvent('import_adif', {
-        import_count: count,
+        import_count: importCount,
+        adif_count: adifCount,
         qso_count: operation.qsoCount,
         refs: (operation.refs || []).map(r => r.type).join(',')
       })
@@ -123,7 +124,7 @@ export default function OperationDataScreen (props) {
         reportError('Error importing ADIF', error)
       }
     })
-  }, [dispatch, operation])
+  }, [dispatch, operation, qsos])
 
   const selectedExportOptions = useMemo(() => exportOptions.filter(option => (settings.exportTypes?.[option.exportType] ?? option.selectedByDefault) !== false), [exportOptions, settings.exportTypes])
 


### PR DESCRIPTION
This uses existing default score handler, with minor change that identical timestamps (which occur when importing same adif) qualify as dupe.

If preferable, could add custom dedupe logic.