### PR TITLE
Don't suggest exporting a SOTA hunter log if the only SOTA QSOs are deleted

### DIFF
--- a/src/extensions/activities/sota/SOTAExtension.js
+++ b/src/extensions/activities/sota/SOTAExtension.js
@@ -232,7 +232,7 @@ const ReferenceHandler = {
         titleTemplate: `{call}: ${Info.shortName} at ${[ref.ref, ref.name].filter(x => x).join(' - ')} on {date}`
       }]
     } else { // "export" hook
-      const hasSOTA = qsos?.find(q => findRef(q, Info.huntingType))
+      const hasSOTA = qsos?.find(q => findRef(q, Info.huntingType) && !q.deleted)
       const isSOTAActivation = findRef(operation, Info.activationType)
       if (!hasSOTA || isSOTAActivation) return null
       console.log('SOTA Hunter')


### PR DESCRIPTION
On my last activation, I started a QSO with a SOTA operator and couldn't complete it, but accidentally hit the Save button. I then went back and deleted the QSO.

When it came to export my logs, PoLo suggested to export a SOTA hunter log. When I tried this, the file was (correctly) empty. However, I think the suggestion to export the log shouldn't have been there.

This patch fixes the issue, meaning that for the SOTA hunter log to be recommended, you must have QSOs with SOTA references _and_ those QSOs must be non-deleted.