### PR TITLE
Attempt to fetch multiple references for POTA spots

### DIFF
--- a/src/extensions/activities/pota/POTAExtension.js
+++ b/src/extensions/activities/pota/POTAExtension.js
@@ -112,8 +112,9 @@ const SpotsHook = {
         spotCommentPromise.unsubscribe && spotCommentPromise.unsubscribe()
         const spotComments = spotCommentResults.data || []
 
-        const filteredSpotComment = spotComments.find(
-          x => x.source?.startsWith('Ham2K Portable Logger') && x.comments.match(/\b[0-9]+-fer: .+$/)
+        const filteredSpotComment = spotComments.find(x =>
+          x.source.startsWith('Ham2K Portable Logger') &&
+          x.comments.match(/\b[0-9]+-fer:(?: [A-Z0-9]+-(?:[0-9]{4,5}|TEST)){2,}$/)
         )
         if (filteredSpotComment) {
           const newRefs = filteredSpotComment.comments

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
@@ -5,24 +5,38 @@
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback } from 'react'
-import { useSelector } from 'react-redux'
+import React, { useCallback, useMemo } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { useFindHooks } from '../../../extensions/registry'
+import { selectRuntimeOnline } from '../../../store/runtime'
+import { selectSettings } from '../../../store/settings'
 import { selectQSOs } from '../../../store/qsos'
+
 import SpotsPanel from './components/SpotsPanel'
 
 export default function OpSpotsTab ({ navigation, route }) {
   const operation = route.params.operation
   const qsos = useSelector(state => selectQSOs(state, route.params.operation.uuid))
+  const dispatch = useDispatch()
+  const settings = useSelector(selectSettings)
+  const online = useSelector(selectRuntimeOnline)
+  const spotsHooks = useFindHooks('spots')
 
-  const handleSelect = useCallback(({ spot }) => {
+  const extraSpotInfoHooks = useMemo(() => spotsHooks.filter(hook => hook?.extraSpotInfo), [spotsHooks])
+
+  const handleSelect = useCallback(async ({ spot }) => {
     if (spot._ourSpot) return
+
+    for (const hook of extraSpotInfoHooks) {
+      await hook.extraSpotInfo({ online, settings, dispatch, spot })
+    }
 
     if (route?.params?.splitView) {
       navigation.navigate('Operation', { ...route?.params, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
     } else {
       navigation.navigate('OpLog', { qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
     }
-  }, [navigation, route?.params])
+  }, [navigation, route?.params, extraSpotInfoHooks, dispatch, online, settings])
 
   return (
     <SpotsPanel operation={operation} qsos={qsos} onSelect={handleSelect} />


### PR DESCRIPTION
This utilises the known structure of the spots from fellow Ham2k PoLo users to fetch their extra park references when hunting.

As this requires extra calls to POTA API, it's just too slow to do when POTA returning 100s of spots, so this added feature is only used when selecting a spot.


https://github.com/user-attachments/assets/8e050815-51b0-4526-8af8-46ff486617a0

