### PR TITLE
Fix general operation scoring / duplicate flagging

### DIFF
--- a/src/extensions/scoring/index.js
+++ b/src/extensions/scoring/index.js
@@ -28,6 +28,8 @@ export function scoringHandlersForOperation (operation, settings) {
     }
   })
 
+  if (scoringHandlers.length === 0) scoringHandlers.push({ handler: DefaultScoringHandler, ref: { type: 'defaultOperation' } })
+
   // Get handlers for general hunting activities
   findHooks('activity').forEach(hook => {
     const type = hook.generalHuntingType && hook.generalHuntingType({ operation, settings })
@@ -37,8 +39,6 @@ export function scoringHandlersForOperation (operation, settings) {
       scoringKeys[handler.key] = true
     }
   })
-
-  if (scoringHandlers.length === 0) scoringHandlers.push({ handler: DefaultScoringHandler, ref: { type: 'defaultOperation' } })
 
   scoringHandlers.push({ handler: DXCCScoringHandler, ref: {} })
   scoringKeys[DXCCScoringHandler.key] = true


### PR DESCRIPTION
As scoring handlers for general hunting are always added, the handlers array wasn't empty to check for adding default score handler. Simply moved this check to post adding activty based handlers.