### PR TITLE
Confirm spots improvements

### DIFF
--- a/src/extensions/activities/pota/POTAConfirmFromSpots.js
+++ b/src/extensions/activities/pota/POTAConfirmFromSpots.js
@@ -53,6 +53,7 @@ export const ConfirmFromSpotsHook = {
           call: spot.spotter,
           timeInMillis: spot.timeInMillis,
           mode: spot.mode,
+          note: spot.comments,
           spot
         }
       })

--- a/src/store/qsos/actions/confirmFromSpots.js
+++ b/src/store/qsos/actions/confirmFromSpots.js
@@ -41,6 +41,11 @@ export const confirmFromSpots = (options = {}) => async (dispatch, getState) => 
     }
 
     for (const [confirmationName, spots] of Object.entries(hookSpots)) {
+      // Skip if qso already has a confirmation
+      if (qso.qsl?.[confirmationName]?.isGuess === false) {
+        break
+      }
+
       let currentSpot
       // At most two characters can be wrong
       let currentDistance = 3
@@ -70,14 +75,17 @@ export const confirmFromSpots = (options = {}) => async (dispatch, getState) => 
 
       if (currentSpot) {
         const qsl = qso.qsl || {}
+        const isGuess = currentDistance !== 0
         qsl[confirmationName] = {
           spot: currentSpot.spot,
-          isGuess: currentDistance !== 0
+          isGuess
         }
+        const notes = [qso.notes, isGuess ? undefined : currentSpot.note].filter(n => !!n).join(' | ')
         dispatch(actions.addQSO({
           uuid: options.operation.uuid,
           qso: {
             ...qso,
+            notes: notes.length > 0 ? notes : undefined,
             qsl
           }
         }))


### PR DESCRIPTION
Made some tweaks to how confirming spots works:
 1. Removed spots that match the current station to avoid suggesting your own call
 2. Reduced sensitivity so only 2 characters can be wrong to suggest a new call
 3. Don't suggest a spot if it matches an existing log entry
    - Example:
    - Log QSOs: [AB1CD, AB2CD, WF1XZ]
    - Spots: [AB1CD]
    - Only AB1CD is marked as confirmed, AB2CD would not offer a suggestion to correct to AB1CD even if its distance is 1, because AB1CD is a correct call in the log.
  4. Store spot comment as a note