### PR TITLE
Don't include QSLMSG by default in WWFF export

### DIFF
--- a/RELEASE-NOTES.json
+++ b/RELEASE-NOTES.json
@@ -7,6 +7,7 @@
       "List formatting tweaks",
       "Hide RST in list if fields are hidden",
       "Map improvements, including signal strength",
+      "Don't include QSLMSG in WWFF export",
       "Add Polish Gmina Award (by M1SDH, as suggested by SP9MKP)",
       "Add self-spotting for Bunkers on the Air (WWBOTA) programme (by M1SDH)"
     ]

--- a/src/extensions/activities/wwff/WWFFExtension.js
+++ b/src/extensions/activities/wwff/WWFFExtension.js
@@ -205,7 +205,8 @@ const ReferenceHandler = {
         exportData: { refs: [ref] }, // exports only see this one ref
         // Note that compact format uses a space instead of - because of WWFF requirements
         nameTemplate: '{{log.station}}@{{log.ref}} {{compact op.date}}',
-        titleTemplate: '{{>RefActivityTitle}}'
+        titleTemplate: '{{>RefActivityTitle}}',
+        ADIFQslMsgTemplate: ' ' // Don't include
       }]
     }
   },


### PR DESCRIPTION
Requested by W7AAF (KFF area 1 log manager), as this causes errors when uploading logs to the WWFF backend.