### PR TITLE
Raise alerts when SOTA account not logged in for self-spotting

### DIFF
--- a/src/extensions/activities/sota/SOTAExtension.js
+++ b/src/extensions/activities/sota/SOTAExtension.js
@@ -4,6 +4,7 @@
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
+import { Alert } from 'react-native'
 
 import { loadDataFile, removeDataFile } from '../../../store/dataFiles/actions/dataFileFS'
 import { findRef, refsToString } from '../../../tools/refTools'
@@ -61,7 +62,11 @@ const ActivityHook = {
 
   postSpot: SOTAPostSpot,
   isSpotEnabled: ({ operation, settings }) => {
-    return !!settings?.accounts?.sota?.idToken
+    const enabled = !!settings?.accounts?.sota?.idToken
+    if (!enabled) {
+      Alert.alert('Warning', 'Not logged into SOTAWatch for self-spotting. Please go to PoLo settings')
+    }
+    return enabled
   },
 
   Options: SOTAActivityOptions,

--- a/src/extensions/activities/sota/SOTAPostSpot.js
+++ b/src/extensions/activities/sota/SOTAPostSpot.js
@@ -12,7 +12,7 @@ import { ADIF_SUBMODES } from '@ham2k/lib-operation-data'
 
 import { reportError } from '../../../distro'
 
-import { filterRefs } from '../../../tools/refTools'
+import { findRef } from '../../../tools/refTools'
 import { apiSOTA } from '../../../store/apis/apiSOTA'
 
 const validModes = ['AM', 'CW', 'Data', 'DV', 'FM', 'SSB']
@@ -21,36 +21,48 @@ export const SOTAPostSpot = ({ operation, vfo, comments }) => async (dispatch, g
   const state = getState()
   const activatorCallsign = operation.stationCall || state.settings.operatorCall
 
-  const refs = filterRefs(operation, 'sotaActivation')
+  const ref = findRef(operation, 'sotaActivation')
+  const [associationCode, summitCode] = ref.ref.split('/', 2)
+
+  let mode = vfo.mode
+  if (!validModes.includes(mode)) {
+    if (ADIF_SUBMODES.SSB.includes(mode)) {
+      mode = 'SSB'
+    } else if (mode === 'DIGITALVOICE' || ADIF_SUBMODES.DIGITALVOICE.includes(mode)) {
+      mode = 'DV'
+    } else {
+      mode = 'Data' // Reasonable guess
+    }
+  }
+
+  const spot = {
+    associationCode,
+    summitCode,
+    activatorCallsign,
+    frequency: `${vfo.freq / 1000}`, // string
+    mode,
+    comments,
+    type: comments.includes('QRT') ? 'QRT' : 'NORMAL' // Also 'TEST' when debugging
+  }
+
   try {
-    for (const ref of refs) { // Should only be one
-      const [associationCode, summitCode] = ref.ref.split('/', 2)
+    const apiPromise = await dispatch(apiSOTA.endpoints.spot.initiate(spot))
+    await Promise.all(dispatch(apiSOTA.util.getRunningQueriesThunk()))
+    const apiResults = await dispatch((_dispatch, _getState) => apiSOTA.endpoints.spot.select(spot)(_getState()))
+    apiPromise.unsubscribe && apiPromise.unsubscribe()
 
-      let mode = vfo.mode
-      if (!validModes.includes(mode)) {
-        if (ADIF_SUBMODES.SSB.includes(mode)) {
-          mode = 'SSB'
-        } else if (mode === 'DIGITALVOICE' || ADIF_SUBMODES.DIGITALVOICE.includes(mode)) {
-          mode = 'DV'
-        } else {
-          mode = 'Data' // Reasonable guess
-        }
+    if (apiResults?.error) {
+      if (apiResults.error?.status === 403) { // Forbidden, not logged in
+        Alert.alert('Error posting SOTA spot', 'SOTA account logged out. Please log in again in PoLo settings')
+      } else {
+        Alert.alert('Error posting SOTA spot', `${apiResults.error?.status} ${apiResults.error?.data?.message}`)
       }
-      const spot = {
-        associationCode,
-        summitCode,
-        activatorCallsign,
-        frequency: `${vfo.freq / 1000}`, // string
-        mode,
-        comments,
-        type: comments.includes('QRT') ? 'QRT' : 'NORMAL' // Also 'TEST' when debugging
-      }
-
-      // Errors will be logged by apiSOTA
-      await dispatch(apiSOTA.endpoints.spot.initiate(spot))
+      return false
     }
   } catch (error) {
     Alert.alert('Error posting SOTA spot', error.message)
     reportError('Error posting SOTA spot', error)
+    return false
   }
+  return true
 }


### PR DESCRIPTION
When first opening QSO screen, or pressing self-spot button:
![Screenshot From 2025-05-12 17-05-36](https://github.com/user-attachments/assets/7a8c8e1a-6d19-4a3c-8921-c80d0d6f6755)

When logged in, but then get logged out during spotting:
![Screenshot From 2025-05-12 17-23-46](https://github.com/user-attachments/assets/bd1f35bd-11aa-4f30-b2cd-330a94bbc1c9)
