### PR TITLE
Handle case where POTA states is not valid

### DIFF
--- a/src/extensions/activities/pota/POTAExtension.js
+++ b/src/extensions/activities/pota/POTAExtension.js
@@ -386,7 +386,7 @@ const ReferenceHandler = {
 function _simplifyPOTAStates (locationDesc) {
   if (!locationDesc) return ''
   const states = locationDesc.split(',')
-  const oneState = states[0].split('-', 2)[1].trim()
+  const oneState = states[0].split('-', 2)[1]?.trim()
   if (states.length > 1) {
     return `${oneState}+${states.length - 1}`
   } else {


### PR DESCRIPTION
In some cases, for example "K-TEST" park, states has invalid data, and such the trim can fail being called on undefined.