### PR TITLE
WWBOTA Spot Status

### DIFF
--- a/src/extensions/activities/wwbota/WWBOTAPostSpot.js
+++ b/src/extensions/activities/wwbota/WWBOTAPostSpot.js
@@ -10,7 +10,7 @@ import { Alert } from 'react-native'
 
 import { reportError } from '../../../distro'
 
-import { setOperationData } from '../../../store/operations'
+import { setOperationData, debouncedDispatch } from '../../../store/operations'
 import { filterRefs } from '../../../tools/refTools'
 import { apiWWBOTA } from '../../../store/apis/apiWWBOTA'
 import { Info } from './WWBOTAInfo'
@@ -64,10 +64,11 @@ export const WWBOTAPostSpot = ({ operation, vfo, comments }) => async (dispatch,
       apiPromise.unsubscribe && apiPromise.unsubscribe()
 
       if (apiResults?.data?.id) {
-        dispatch(setOperationData({
+        await dispatch(setOperationData({
           uuid: operation.uuid,
           spotIds: { ...operation?.spotIds, [Info.key]: apiResults?.data?.id }
         }))
+        debouncedDispatch.flush()
       }
     }
     if (apiResults?.error) {

--- a/src/store/operations/actions/setOperationData.js
+++ b/src/store/operations/actions/setOperationData.js
@@ -16,7 +16,7 @@ import GLOBAL from '../../../GLOBAL'
 function debounceableDispatch (dispatch, action) {
   return dispatch(action())
 }
-const debouncedDispatch = debounce(debounceableDispatch, 2000)
+export const debouncedDispatch = debounce(debounceableDispatch, 2000)
 
 export const setOperationLocalData = (data) => async (dispatch, getState) => {
   try {


### PR DESCRIPTION
Noticed yesterday in my WWBOTA activation didn't get the green success icon for self-spotting like POTA as return status was missing.

However, trying to add it, I was getting the saving of the spot id not happening.

I think issue is with debounce and when returning status of ok, now this is being called: https://github.com/ham2k/app-polo/blob/947fe845362d4ce1223f41d62dae25cf023bffaf/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel/SpotterControl.jsx#L176

I put a "fix" in to test in eaed0a3 which seems to resolve the issue by flushing the debounce function straight away, but probably needs more consideration if the debounce may be at issue, as multiple concurrent edits to operation data could end up not saving things, like I found here.