### PR TITLE
Ignore duplicate spots when spotting to WWFF

### DIFF
--- a/src/extensions/activities/wwff/WWFFPostOtherSpot.js
+++ b/src/extensions/activities/wwff/WWFFPostOtherSpot.js
@@ -32,8 +32,9 @@ export const WWFFPostOtherSpot = ({ comments, qso, spotterCall }) => async (disp
       await Promise.all(dispatch(apiWWFF.util.getRunningQueriesThunk()))
       const apiResults = await dispatch((_dispatch, _getState) => apiWWFF.endpoints.spot.select(spot)(_getState()))
       apiPromise.unsubscribe && apiPromise.unsubscribe()
-      if (apiResults?.error) {
-        Alert.alert('Error posting WWFF spot', `Server responded with status ${apiResults.error?.status} ${apiResults.error?.data?.error}`)
+      // Don't worry about duplicates
+      if (apiResults?.error && !apiResults?.error?.data?.message?.match(/Duplicate spot detected/)) {
+        Alert.alert('Error posting WWFF spot', `Server responded with status ${apiResults.error?.status} ${apiResults.error?.data?.message}`)
         return false
       }
     } catch (error) {

--- a/src/extensions/activities/wwff/WWFFPostSelfSpot.js
+++ b/src/extensions/activities/wwff/WWFFPostSelfSpot.js
@@ -36,8 +36,9 @@ export const WWFFPostSelfSpot = ({ operation, vfo, comments }) => async (dispatc
       await Promise.all(dispatch(apiWWFF.util.getRunningQueriesThunk()))
       const apiResults = await dispatch((_dispatch, _getState) => apiWWFF.endpoints.spot.select(spot)(_getState()))
       apiPromise.unsubscribe && apiPromise.unsubscribe()
-      if (apiResults?.error) {
-        Alert.alert('Error posting WWFF spot', `Server responded with status ${apiResults.error?.status} ${apiResults.error?.data?.error}`)
+      // Don't worry about duplicates
+      if (apiResults?.error && !apiResults?.error?.data?.message?.match(/Duplicate spot detected/)) {
+        Alert.alert('Error posting WWFF spot', `Server responded with status ${apiResults.error?.status} ${apiResults.error?.data?.message}`)
         return false
       }
     } catch (error) {


### PR DESCRIPTION
If it's flagged as duplicate, means your already on the cluster, and error message is more annoying than helpful.

This also fixed bug with error messages always being undefined.