### PR TITLE
Add Wavelog Support

### DIFF
--- a/src/screens/OperationScreens/OpSettingsTab/OpSettingsTab.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OpSettingsTab.jsx
@@ -24,7 +24,6 @@ import { findBestHook, findHooks } from '../../../extensions/registry'
 import { defaultReferenceHandlerFor } from '../../../extensions/core/references'
 import { trackEvent } from '../../../distro'
 import { paperNameOrHam2KIcon } from '../../components/Ham2KIcon'
-import { ExportWavelogDialog } from './components/ExportWavelogDialog'
 
 function prepareStyles (baseStyles) {
   return {
@@ -234,25 +233,11 @@ export default function OpSettingsTab ({ navigation, route }) {
           onPress={() => navigation.navigate('OperationData', { operation: operation.uuid })}
         />
         <Ham2kListItem
-          title="Export QSOs to Wavelog"
-          description="Send all QSOs for this operation to Wavelog"
-          left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="cloud-upload-outline" />}
-          onPress={() => setShowExportWavelog(true)}
-        />
-        <Ham2kListItem
           title="Use as template"
           description="Start a new operation with similar settings"
           left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="content-copy" />}
           onPress={cloneOperation}
         />
-        {showExportWavelog && (
-          <ExportWavelogDialog
-            operation={operation}
-            qsos={qsos || []}
-            visible={showExportWavelog}
-            onDialogDone={() => setShowExportWavelog(false)}
-          />
-        )}
       </Ham2kListSection>
 
       <Ham2kListSection titleStyle={{ color: styles.theme.colors.error }} title={'The Danger Zone'}>

--- a/src/screens/OperationScreens/OpSettingsTab/OpSettingsTab.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OpSettingsTab.jsx
@@ -122,28 +122,6 @@ export default function OpSettingsTab ({ navigation, route }) {
   }, [dispatch, navigation, operation, settings])
 
   const safeAreaInsets = useSafeAreaInsets()
-  const [showExportWavelog, setShowExportWavelog] = useState(false)
-
-  // Ensure QSOs are loaded for this operation
-  useEffect(() => {
-    setImmediate(async () => {
-      await dispatch(loadOperation(route.params.operation.uuid))
-      await dispatch(loadQSOs(route.params.operation.uuid))
-    })
-  }, [route.params.operation.uuid, dispatch])
-
-  // DEBUG: Log the full qsos state to find the correct structure
-  const qsosState = useSelector(state => state.qsos)
-  useEffect(() => {
-    console.log('qsosState', qsosState)
-  }, [qsosState])
-
-  // Try to select QSOs from the most likely locations
-  const qsos = useSelector(state =>
-    Array.isArray(state.qsos?.qsos?.[operation.uuid])
-      ? state.qsos.qsos[operation.uuid]
-      : []
-  )
 
   return (
     <ScrollView style={{ flex: 1 }}>

--- a/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
@@ -40,12 +40,11 @@ export default function OperationDataScreen (props) {
   const ourInfo = useSelector(state => selectOperationCallInfo(state, operation?.uuid))
   const settings = useSelector(selectSettings)
 
-  const [showExportWavelog, setShowExportWavelog] = useState(false)
-
   useEffect(() => { // When starting, make sure all operation data is loaded
     dispatch(loadQSOs(route.params.operation))
     dispatch(loadOperation(route.params.operation))
   }, [route.params.operation, dispatch])
+  const [showExportWavelog, setShowExportWavelog] = useState(false)
 
   useEffect(() => {
     let options = { title: 'Operation Data' }

--- a/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
@@ -6,7 +6,7 @@
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Alert, ScrollView, View } from 'react-native'
 import { Checkbox, List, Menu, Text } from 'react-native-paper'
@@ -28,6 +28,7 @@ import { annotateFromCountryFile } from '@ham2k/lib-country-files'
 import { DXCC_BY_PREFIX } from '@ham2k/lib-dxcc-data'
 import ScreenContainer from '../../components/ScreenContainer'
 import { paperNameOrHam2KIcon } from '../../components/Ham2KIcon'
+import { ExportWavelogDialog } from './components/ExportWavelogDialog'
 
 export default function OperationDataScreen (props) {
   const { navigation, route } = props
@@ -38,6 +39,8 @@ export default function OperationDataScreen (props) {
   const qsos = useSelector(state => selectQSOs(state, operation?.uuid))
   const ourInfo = useSelector(state => selectOperationCallInfo(state, operation?.uuid))
   const settings = useSelector(selectSettings)
+
+  const [showExportWavelog, setShowExportWavelog] = useState(false)
 
   useEffect(() => { // When starting, make sure all operation data is loaded
     dispatch(loadQSOs(route.params.operation))
@@ -218,6 +221,27 @@ export default function OperationDataScreen (props) {
                 onPress={() => {}}
               />
             </Ham2kListSection>
+          )}
+          { settings.wavelogExperiments && (
+          <Ham2kListSection title={'Wavelog Export'} titleStyle={{ color: styles.colors.devMode }}>
+            <Ham2kListItem
+                      title="Export QSOs to Wavelog"
+                      description="Send all QSOs for this operation to Wavelog"
+                      left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="cloud-upload-outline" color={styles.colors.devMode} />}
+                      onPress={() => setShowExportWavelog(true)}
+                      titleStyle={{ color: styles.colors.devMode }}
+                      descriptionStyle={{ color: styles.colors.devMode }}
+                    />
+          </Ham2kListSection>
+          
+          )}
+          { showExportWavelog && (
+            <ExportWavelogDialog
+              operation={operation}
+              qsos={qsos || []}
+              visible={showExportWavelog}
+              onDialogDone={() => setShowExportWavelog(false)}
+            />
           )}
         </ScrollView>
       </SafeAreaView>

--- a/src/screens/OperationScreens/OpSettingsTab/components/ExportWavelogDialog.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/components/ExportWavelogDialog.jsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { List, Button, Dialog, Portal, Text } from 'react-native-paper';
+import { selectSettings } from '../../../../store/settings';
+import { selectOperation } from '../../../../store/operations';
+import { qsonToWavelog } from '../../../../tools/qsonToWavelog';
+
+export function ExportWavelogDialog({ operation, qsos, visible, onDialogDone }) {
+  const dispatch = useDispatch();
+  const settings = useSelector(selectSettings);
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [exportSuccess, setExportSuccess] = useState(false);
+
+  // Reset status when dialog opens
+  useEffect(() => {
+    if (visible) {
+      setStatus('');
+      setExportSuccess(false);
+    }
+  }, [visible]);
+
+  const handleExport = async () => {
+    const wavelog = settings?.wavelog;
+    console.log('Wavelog config:', wavelog, 'Types:', {
+      apiUrl: typeof wavelog?.apiUrl,
+      apiKey: typeof wavelog?.apiKey,
+      stationId: typeof wavelog?.stationId,
+      stationIdValue: wavelog?.stationId,
+    });
+
+    setLoading(true);
+    setStatus('Exporting...');
+    const result = await qsonToWavelog({ operation, qsos, settings });
+    setStatus(result.message);
+    if (result.success) {
+      setExportSuccess(true);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <Portal>
+      <Dialog visible={visible} onDismiss={onDialogDone}>
+        <Dialog.Title>Export QSOs to Wavelog</Dialog.Title>
+        <Dialog.Content>
+          <Text>{status || 'Export all QSOs for this operation to Wavelog.'}</Text>
+        </Dialog.Content>
+        <Dialog.Actions>
+          {exportSuccess ? (
+            <Button onPress={onDialogDone}>Done</Button>
+          ) : (
+            <>
+              <Button onPress={onDialogDone} disabled={loading}>Cancel</Button>
+              <Button onPress={handleExport} loading={loading} disabled={loading}>Export</Button>
+            </>
+          )}
+        </Dialog.Actions>
+      </Dialog>
+    </Portal>
+  );
+}

--- a/src/screens/SettingsScreens/screens/CreditsSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/CreditsSettingsScreen.jsx
@@ -130,6 +130,13 @@ export default function CreditsSettingsScreen ({ navigation, splitView }) {
             left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="account" />}
             onPress={() => navigation.navigate('CallInfo', { call: 'W8NI' })}
           />
+          <Ham2kListItem
+            title={'Emma • VA2EMZ/K0UWU'}
+            description={'Code: Wavelog Sync'}
+            left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="account" />}
+            onPress={() => navigation.navigate('CallInfo', { call: 'W9ILY' })}
+          />
+
         </Ham2kListSection>
         <View style={{ height: safeAreaInsets.bottom }} />
 

--- a/src/screens/SettingsScreens/screens/DevModeSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/DevModeSettingsScreen.jsx
@@ -7,7 +7,7 @@
 
 /* eslint-disable react/no-unstable-nested-components */
 import React, { useCallback } from 'react'
-import { IconButton, List } from 'react-native-paper'
+import { IconButton, List, Switch } from 'react-native-paper'
 import { Alert, ScrollView, View } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import { pick, keepLocalCopy } from '@react-native-documents/picker'
@@ -188,6 +188,17 @@ export default function DevModeSettingsScreen ({ navigation, splitView }) {
             titleStyle={{ color: styles.colors.devMode }}
             descriptionStyle={{ color: styles.colors.devMode }}
             onPress={handleImportFiles}
+          />
+        </Ham2kListSection>
+        <Ham2kListSection title={'Experiments'}>
+          <Ham2kListItem
+            title="Enable Wavelog Experiments"
+            description={settings.wavelogExperiments ? 'Experimental Wavelog features are enabled' : 'Wavelog is Disabled'}
+            left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="test-tube" color={styles.colors.devMode} />}
+            right={() => <Switch value={!!settings.wavelogExperiments} onValueChange={(value) => dispatch(setSettings({ wavelogExperiments: value }))} />}
+            onPress={() => dispatch(setSettings({ wavelogExperiments: !settings.wavelogExperiments }))}
+            titleStyle={{ color: styles.colors.devMode }}
+            descriptionStyle={{ color: styles.colors.devMode }}
           />
         </Ham2kListSection>
         <Ham2kListSection title={'Manage Database'}>

--- a/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
@@ -216,17 +216,6 @@ function MainSettingsOptions ({ settings, styles, navigation, splitView }) {
           />
         )}
 
-        {settings.wavelogExperiments && (
-          <Ham2kListItem
-            title="Wavelog Settings"
-            description={'Configure Wavelog API connection'}
-            onPress={() => navigation.navigate('Settings', { screen: 'WavelogSettings' })}
-            titleStyle={{ color: styles.colors.devMode }}
-            descriptionStyle={{ color: styles.colors.devMode }}
-            left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="cloud-upload-outline" color={styles.colors.devMode} />}
-          />
-        )}
-
       </Ham2kListSection>
 
       <Ham2kListSection>
@@ -249,6 +238,16 @@ function MainSettingsOptions ({ settings, styles, navigation, splitView }) {
         {accountSettingHooks.map((hook) => (
           <hook.SettingItem key={hook.key} settings={settings} styles={styles} />
         ))}
+        {settings.wavelogExperiments && (
+          <Ham2kListItem
+            title="Wavelog Settings"
+            description={'Configure Wavelog API connection'}
+            onPress={() => navigation.navigate('Settings', { screen: 'WavelogSettings' })}
+            titleStyle={{ color: styles.colors.devMode }}
+            descriptionStyle={{ color: styles.colors.devMode }}
+            left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="cloud-upload-outline" color={styles.colors.devMode} />}
+          />
+        )}
       </Ham2kListSection>
 
       <MainSettingsForDistribution settings={settings} styles={styles} />

--- a/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
@@ -40,6 +40,7 @@ import GeneralSettingsScreen from './GeneralSettingsScreen'
 import LoggingSettingsScreen from './LoggingSettingsScreen'
 import VersionSettingsScreen from './VersionSettingsScreen'
 import SyncSettingsScreen from './SyncSettingsScreen'
+import WavelogSettingsScreen from './WavelogSettingsScreen'
 
 import { MainSettingsForDistribution } from '../../../distro'
 import NoticesSettingsScreen from './NoticesSettingsScreen'
@@ -215,6 +216,13 @@ function MainSettingsOptions ({ settings, styles, navigation, splitView }) {
           />
         )}
 
+        <Ham2kListItem
+          title="Wavelog Settings"
+          description={'Configure Wavelog API connection'}
+          onPress={() => navigation.navigate('Settings', { screen: 'WavelogSettings' })}
+          left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="cloud-upload-outline" />}
+        />
+
       </Ham2kListSection>
 
       <Ham2kListSection>
@@ -389,6 +397,11 @@ function settingsScreensArray ({ includeMain, topLevelBack, splitView }) {
     <Stack.Screen name="ExtensionScreen" key="ExtensionScreen"
       options={{ title: 'Extension' }}
       component={ExtensionScreen}
+    />,
+
+    <Stack.Screen name="WavelogSettings" key="WavelogSettings"
+      options={{ title: 'Wavelog Settings', headerBackVisible: topLevelBack }}
+      component={WavelogSettingsScreen}
     />
 
   ]

--- a/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/MainSettingsScreen.jsx
@@ -216,12 +216,16 @@ function MainSettingsOptions ({ settings, styles, navigation, splitView }) {
           />
         )}
 
-        <Ham2kListItem
-          title="Wavelog Settings"
-          description={'Configure Wavelog API connection'}
-          onPress={() => navigation.navigate('Settings', { screen: 'WavelogSettings' })}
-          left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="cloud-upload-outline" />}
-        />
+        {settings.wavelogExperiments && (
+          <Ham2kListItem
+            title="Wavelog Settings"
+            description={'Configure Wavelog API connection'}
+            onPress={() => navigation.navigate('Settings', { screen: 'WavelogSettings' })}
+            titleStyle={{ color: styles.colors.devMode }}
+            descriptionStyle={{ color: styles.colors.devMode }}
+            left={() => <List.Icon style={{ marginLeft: styles.oneSpace * 2 }} icon="cloud-upload-outline" color={styles.colors.devMode} />}
+          />
+        )}
 
       </Ham2kListSection>
 

--- a/src/screens/SettingsScreens/screens/WavelogSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/WavelogSettingsScreen.jsx
@@ -1,0 +1,122 @@
+/*
+ * WavelogSettingsScreen.jsx
+ * Settings screen for Wavelog integration (API URL + API Key + Station picker)
+ */
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { View, ScrollView } from 'react-native';
+import { Text, TextInput, Button, List, HelperText } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { selectSettings, setSettings } from '../../../store/settings';
+import ScreenContainer from '../../components/ScreenContainer';
+import { useThemedStyles } from '../../../styles/tools/useThemedStyles';
+
+export default function WavelogSettingsScreen({ navigation }) {
+  const dispatch = useDispatch();
+  const safeAreaInsets = useSafeAreaInsets();
+  const styles = useThemedStyles();
+  const settings = useSelector(selectSettings);
+  const [apiUrl, setApiUrl] = useState(settings?.wavelog?.apiUrl || '');
+  const [apiKey, setApiKey] = useState(settings?.wavelog?.apiKey || '');
+  const [stations, setStations] = useState([]);
+  const [stationId, setStationId] = useState(settings?.wavelog?.stationId || '');
+  const [fetching, setFetching] = useState(false);
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const fetchStations = async () => {
+    setFetching(true);
+    setError('');
+    setStations([]);
+    try {
+      const url = `${apiUrl.replace(/\/$/, '')}/api/station_info/${apiKey}`;
+      const response = await fetch(url, { method: 'GET' });
+      if (!response.ok) throw new Error('Failed to fetch stations');
+      const data = await response.json();
+      if (Array.isArray(data)) {
+        setStations(data);
+      } else if (Array.isArray(data.payload)) {
+        setStations(data.payload);
+      } else {
+        setError('No stations found or invalid response');
+      }
+    } catch (e) {
+      setError('Error fetching stations: ' + e.message);
+    }
+    setFetching(false);
+  };
+
+  const saveConfig = () => {
+    setSaving(true);
+    dispatch(setSettings({
+      wavelog: {
+        apiUrl,
+        apiKey,
+        stationId
+      },
+    }));
+    setSaving(false);
+  };
+
+  return (
+    <ScreenContainer>
+      <View style={{ flex: 1, padding: 16, paddingBottom: safeAreaInsets.bottom }}>
+        <Text variant="titleLarge" style={{ marginBottom: 16 }}>Wavelog Configuration</Text>
+        <TextInput
+          label="Wavelog API URL"
+          value={apiUrl}
+          onChangeText={setApiUrl}
+          style={{ marginBottom: 12 }}
+          autoCapitalize="none"
+        />
+        <TextInput
+          label="API Key"
+          value={apiKey}
+          onChangeText={setApiKey}
+          style={{ marginBottom: 12 }}
+          autoCapitalize="none"
+        />
+        <Button mode="outlined" onPress={fetchStations} loading={fetching} disabled={fetching || !apiUrl || !apiKey} style={{ marginBottom: 12 }}>
+          Fetch Stations
+        </Button>
+        {error ? <HelperText type="error">{error}</HelperText> : null}
+        {stations.length > 0 && (
+          <ScrollView style={{ maxHeight: 300, marginBottom: 12 }}>
+            <List.Section title="Select Station">
+              {stations.map(station => {
+                const id = station.id || station.station_profile_id || station.station_id;
+                const profileName = station.station_profile_name || station.name || station.label || station.station_callsign || '';
+                return (
+                  <List.Item
+                    key={id}
+                    title={profileName}
+                    description={station.station_callsign || station.label || ''}
+                    onPress={() => setStationId(id)}
+                    left={props => <List.Icon {...props} icon={stationId === id ? 'check-circle' : 'radiobox-blank'} />}
+                    style={{ backgroundColor: stationId === id ? styles.colors.primaryLighter : undefined }}
+                  />
+                );
+              })}
+            </List.Section>
+          </ScrollView>
+        )}
+        {stationId && (
+          <HelperText type="info" style={{ marginBottom: 8 }}>
+            Selected station:{' '}
+            {(() => {
+              const selected = stations.find(station =>
+                (station.id || station.station_profile_id || station.station_id) === stationId
+              );
+              return selected
+                ? (selected.station_profile_name || selected.name || selected.label || selected.station_callsign || stationId)
+                : stationId;
+            })()}
+          </HelperText>
+        )}
+        <Button mode="contained" onPress={saveConfig} loading={saving} disabled={saving || !apiUrl || !apiKey || !stationId} style={{ marginTop: 16 }}>
+          Save
+        </Button>
+      </View>
+    </ScreenContainer>
+  );
+}

--- a/src/tools/qsonToWavelog.js
+++ b/src/tools/qsonToWavelog.js
@@ -1,0 +1,92 @@
+/*
+ * qsonToWavelog.js
+ * Export QSOs to Wavelog format and upload via API
+ */
+import { qsonToADIF } from './qsonToADIF';
+import packageJson from '../../package.json';
+
+/**
+ * Export QSOs to Wavelog for an operation
+ * @param {Object} params
+ * @param {Object} params.operation
+ * @param {Array} params.qsos
+ * @param {Object} params.settings
+ * @returns {Promise<{success: boolean, message: string}>}
+ */
+export async function qsonToWavelog({ operation, qsos, settings }) {
+  const wavelog = settings?.wavelog;
+  if (
+    !wavelog?.apiUrl ||
+    !wavelog?.apiKey ||
+    !wavelog?.stationId
+  ) {
+    return { success: false, message: 'Wavelog config is incomplete. Please set API URL, API Key, and Station in settings.' };
+  }
+
+  // Ensure QSOs is a non-empty array
+  if (!Array.isArray(qsos) || qsos.length === 0) {
+    console.warn('[Wavelog Export] No QSOs provided for export. The QSOs array is empty or invalid.');
+    return { success: false, message: 'No QSOs to export. Please ensure you have selected QSOs for export.' };
+  }
+
+  // Compose ADIF string using qsonToADIF
+  let adifStr = qsonToADIF({ operation, qsos, settings, handler: { key: 'adif' } });
+  console.log('[Wavelog Export] Exporting QSOs:', qsos);
+  console.log('[Wavelog Export] ADIF string:', adifStr);
+
+  // Prepare JSON payload for POST
+  const payload = {
+    key: wavelog.apiKey.trim(),
+    station_profile_id: String(wavelog.stationId).trim(),
+    type: 'adif',
+    string: adifStr
+  };
+  const postData = JSON.stringify(payload);
+
+  // Ensure the URL ends with /api/qso
+  const apiUrl = wavelog.apiUrl.replace(/\/$/, '') + '/api/qso';
+  console.log('[Wavelog Export] Uploading to URL:', apiUrl);
+
+  try {
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': `Ham2K-PoLo/${packageJson.version}`
+      },
+      body: postData
+    });
+
+    if (response.ok) {
+      // Any 2xx response is considered a success.
+      // We can still check for an explicit failure message in the body, just in case.
+      const responseText = await response.text();
+      try {
+        if (responseText) {
+          const responseData = JSON.parse(responseText);
+          if (responseData.status === 'failed') {
+            return { success: false, message: 'Wavelog reported failure: ' + (responseData.reason || responseText) };
+          }
+        }
+      } catch (e) {
+        // Response is not JSON. Since status is OK, we assume success.
+        console.log('[Wavelog Export] Non-JSON success response from Wavelog:', responseText);
+      }
+      return { success: true, message: 'QSOs exported to Wavelog.' };
+    } else {
+      // Not a 2xx response, so it's a failure.
+      const responseText = await response.text();
+      let reason = responseText;
+      try {
+        const responseData = JSON.parse(responseText);
+        reason = responseData.reason || responseText;
+      } catch (e) {
+        // Not JSON, use the text.
+      }
+      return { success: false, message: `Wavelog upload failed: ${response.statusText} (${response.status}). ${reason.substring(0, 200)}` };
+    }
+  } catch (e) {
+    console.error('[Wavelog Export] Network error:', e);
+    return { success: false, message: 'Wavelog upload error: ' + e.message + ' (URL: ' + apiUrl + ')'};
+  }
+}


### PR DESCRIPTION
Adds Wavelog Export support natively into the app:

Configure Station/URL/Api Key inside settings:
![](https://quack.pics/u/4c30104f-5f7d-49da-9435-515b6d6e1621.png)

Export QSOS to wavelog from operation tab:
![](https://quack.pics/u/7e85883f-c27a-4a9b-8eeb-fbea0dc38e2d.gif)