### PR TITLE
Persist spot confirmations to DB

### DIFF
--- a/src/store/qsos/actions/confirmFromSpots.js
+++ b/src/store/qsos/actions/confirmFromSpots.js
@@ -5,7 +5,8 @@
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { actions, selectQSOs } from '../qsosSlice'
+import { selectQSOs } from '../qsosSlice'
+import { addQSOs } from '../../../store/qsos'
 import { findHooks } from '../../../extensions/registry'
 import { get as getDistance } from 'fast-levenshtein'
 
@@ -34,6 +35,7 @@ export const confirmFromSpots = (options = {}) => async (dispatch, getState) => 
 
   const stationCall = options.operation.stationCall
   const qsoCalls = new Set(qsos.map(qso => qso?.their?.call))
+  const updatedQSOs = []
   for (const qso of qsos) {
     const call = qso?.their?.call
     if (!call) {
@@ -81,17 +83,19 @@ export const confirmFromSpots = (options = {}) => async (dispatch, getState) => 
           isGuess
         }
         const notes = [qso.notes, isGuess ? undefined : currentSpot.note].filter(n => !!n).join(' | ')
-        dispatch(actions.addQSO({
-          uuid: options.operation.uuid,
-          qso: {
-            ...qso,
-            notes: notes.length > 0 ? notes : undefined,
-            qsl
-          }
-        }))
+        updatedQSOs.push({
+          ...qso,
+          notes: notes.length > 0 ? notes : undefined,
+          qsl
+        })
       }
     }
   }
+
+  dispatch(addQSOs({
+    uuid: options.operation.uuid,
+    qsos: updatedQSOs
+  }))
 }
 
 function sameUTCDay (aMillis, bMillis) {


### PR DESCRIPTION
This will save the notes from the spots to the QSOs so they can be exported.