### PR TITLE
Fix issue with SOTA spots frequency excess precision

### DIFF
--- a/src/extensions/activities/sota/SOTAPostOtherSpot.js
+++ b/src/extensions/activities/sota/SOTAPostOtherSpot.js
@@ -41,7 +41,7 @@ export const SOTAPostOtherSpot = ({ comments, qso }) => async (dispatch) => {
     associationCode,
     summitCode,
     activatorCallsign,
-    frequency: `${qso.freq / 1000}`, // string
+    frequency: (qso.freq / 1000).toFixed(5).replace(/0?0$/, ''), // string
     mode,
     comments,
     type: comments.match(/QRT/i) ? 'QRT' : 'NORMAL' // Also 'TEST' when debugging

--- a/src/extensions/activities/sota/SOTAPostSelfSpot.js
+++ b/src/extensions/activities/sota/SOTAPostSelfSpot.js
@@ -43,7 +43,7 @@ export const SOTAPostSelfSpot = ({ operation, vfo, comments }) => async (dispatc
       associationCode,
       summitCode,
       activatorCallsign,
-      frequency: `${vfo.freq / 1000}`, // string
+      frequency: (vfo.freq / 1000).toFixed(5).replace(/0?0$/, ''), // string
       mode,
       comments,
       type: comments.match(/QRT/i) ? 'QRT' : 'NORMAL' // Also 'TEST' when debugging


### PR DESCRIPTION
https://forums.ham2k.com/t/self-spotting-can-create-frequencies-with-excess-precision/1274/2

Truncates to no more than 5 numbers, and strips last 2 zeros e.g. `14.120000002 -> 14.120`; `145.512500 -> 145.5125`;