### PR TITLE
Adds Big Thumbs mode: logging directly from spots tab.

### DIFF
--- a/RELEASE-NOTES.json
+++ b/RELEASE-NOTES.json
@@ -7,7 +7,8 @@
       "Auto self-spotting every 10 minutes",
       "Allow spaces in commands (try 'SPOT HERE')",
       "Fix missing keystrokes on Android when pressing 'send' too fast",
-      "Note expansion now works with callsign stacking"
+      "Note expansion now works with callsign stacking",
+      "Added Big Thumbs mode to enable logging from the spot list"
     ]
   },
   "25.9.3": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,6 +49,7 @@ import SpotsScreen from './screens/SpotsScreen/SpotsScreen'
 import OpInfoScreen from './screens/OperationScreens/OpInfoScreen'
 import OperationDetailsScreen from './screens/OperationScreens/OpSettingsTab/OperationDetailsScreen'
 import OperationLocationScreen from './screens/OperationScreens/OpSettingsTab/OperationLocationScreen'
+import OpSpotsModal from './screens/OperationScreens/OpSpotsTab/OpSpotsModal'
 
 const Stack = createNativeStackNavigator()
 
@@ -191,6 +192,11 @@ function MainApp ({ navigationTheme }) {
           <Stack.Screen name="Settings"
             options={{ title: 'Settings', headerShown: false }}
             component={MainSettingsScreen}
+          />
+
+          <Stack.Screen name="OpSpotModal"
+            options={{ title: 'Spot Logged', headerShown: false, presentation: 'modal' }}
+            component={OpSpotsModal}
           />
         </Stack.Navigator>
       </NavigationContainer>

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
@@ -1,27 +1,27 @@
 // cmw
 
-import { useEffect, useState, useRef, useCallback } from 'react'
-import { View, Text, Animated } from 'react-native'
-import { TouchableRipple, ProgressBar } from 'react-native-paper'
+import { useEffect, useState, useCallback } from 'react'
+import { View, Text } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
 import cloneDeep from 'clone-deep'
 
 import { parseCallsign } from '@ham2k/lib-callsigns'
 import { bandForFrequency } from '@ham2k/lib-operation-data'
 
-import { expandRSTValues, parseStackedCalls } from '../../../tools/callsignTools'
 import { annotateQSO, useCallLookup } from '../OpLoggingTab/components/LoggingPanel/useCallLookup.js'
+import { H2kPressable, H2kMarkdown } from '../../../ui'
 import { trackEvent } from '../../../distro'
 import { findHooks } from '../../../extensions/registry'
 import { addQSOs, selectQSOs } from '../../../store/qsos'
-import { logTimer } from '../../../tools/perfTools'
-// import { selectRuntimeOnline } from '../../../store/runtime'
 import { selectSettings } from '../../../store/settings'
 import { selectOperationCallInfo } from '../../../store/operations'
 import { selectVFO } from '../../../store/station/stationSlice'
+import { logTimer } from '../../../tools/perfTools'
+import { expandRSTValues, parseStackedCalls } from '../../../tools/callsignTools'
 import { useThemedStyles } from '../../../styles/tools/useThemedStyles'
 
 const DEBUG = false
+let submitTimeout
 
 function prepareStyles (themeStyles, themeColor) {
   console.log(themeStyles)
@@ -29,7 +29,7 @@ function prepareStyles (themeStyles, themeColor) {
   const white = '#fff'
   const black = '#000'
   const grey = '#bbb'
-  const grey2 = '#222'
+  // const grey2 = '#222'
   const grey3 = '#333'
 
   const commonStyles = {
@@ -165,10 +165,7 @@ export default function OpSpotsModal ({ navigation, route }) {
   const ourInfo = useSelector(state => selectOperationCallInfo(state, operation?.uuid))
   const vfo = useSelector(state => selectVFO(state))
 
-  const { call, guess, lookup, refs, status, when } = useCallLookup(route.params.qso)
-
-  //   console.log('callLookup results')
-  //   console.log([call, guess, lookup, refs, status, when])
+  const { guess } = useCallLookup(route.params.qso)
 
   useEffect(() => { // Validate and analyze the callsign
     const { call } = parseStackedCalls(route.params.qso?.their?.call ?? '')
@@ -182,95 +179,113 @@ export default function OpSpotsModal ({ navigation, route }) {
     }
   }, [route.params.qso?.their?.call])
 
+  // Since our fields and logic often perform some async work,
+  // we need to wait a few milliseconds before submitting to ensure all async work is complete.
+  // But we can't just use a timeout, because we need the function to bind to the latest values.
+  // So we use a state variable and a callback function to set it and an effect to actually submit..
+  const [doSubmit, setDoSubmit] = useState(false)
+
+  const handleSubmit = useCallback(() => { //
+    if (submitTimeout) clearTimeout(submitTimeout)
+
+    submitTimeout = setTimeout(() => {
+      setDoSubmit(true)
+    }, 50)
+  }, [setDoSubmit])
+
   useEffect(() => {
-    const qso = route.params.qso
+    if (!doSubmit) return
 
-    if (isValidQSO && !qso.deleted) {
-      // setCurrentSecondaryControl(undefined)
+    setDoSubmit(false)
 
-      // if (qso?._isNew && qso?._manualTime && qso.startAtMillis) {
-      //   let nextManualTime = qso.startAtMillis + (60 * 1000)
+    // copy out the params' qso to operate on it
+    const qso = cloneDeep(route.params.qso)
 
-      //   if (qsos.length > 0) {
-      //     const diff = Math.abs(qso.startAtMillis - qsos[qsos.length - 1].startAtMillis)
-      //     if (diff >= 1000) {
-      //       nextManualTime = qso.startAtMillis + Math.min(diff, 60 * 5000)
-      //     }
-      //   }
-      //   // No need to await this one, can happen in parallel
-      //   dispatch(setOperationLocalData({ uuid: operation.uuid, _nextManualTime: nextManualTime }))
-      // }
+    setTimeout(async () => { // Run inside a setTimeout to allow for async functions
+      if (isValidQSO && !qso.deleted) {
+        delete qso._isNew
+        delete qso._willBeDeleted
+        delete qso.deleted
 
-      delete qso._isNew
-      delete qso._willBeDeleted
-      delete qso.deleted
-
-      if (qso.freq) {
-        qso.band = bandForFrequency(qso.freq)
-      }
-
-      if (!qso.startAtMillis) qso.startAtMillis = (new Date()).getTime()
-      qso.startAt = new Date(qso.startAtMillis).toISOString()
-      if (qso.endAtMillis) qso.endAt = new Date(qso.endAtMillis).toISOString()
-      qso.our = qso.our || {}
-      qso.our.call = qso.our.call || ourInfo?.call
-      qso.our.operatorCall = qso.our.operatorCall || operation.local?.operatorCall
-      qso.our.sent = expandRSTValues(qso.our.sent, qso.mode)
-
-      qso.their = qso.their || {}
-      qso.their.sent = expandRSTValues(qso.their.sent, qso.mode)
-      let lastUUID
-
-      const { call, allCalls } = parseStackedCalls(qso?.their?.call ?? '')
-      const multiQSOs = []
-      for (let i = 0; i < allCalls.length; i++) {
-        let oneQSO = qso
-        qso.their.call = call
-        if (allCalls.length > 1) { // If this is a multi-call QSO, we need to clone and annotate the QSO for each call
-          oneQSO = cloneDeep(qso)
-          if (i > 0) oneQSO.uuid = null
-          oneQSO.their.call = allCalls[i]?.trim()
-          oneQSO.their.guess = {}
-          oneQSO.their.lookup = {}
-          oneQSO = annotateQSO({ qso: oneQSO, online: false, settings, dispatch })
-          oneQSO._needsLookup = true
+        if (qso.freq) {
+          qso.band = bandForFrequency(qso.freq)
         }
-        multiQSOs.push(oneQSO)
 
-        const eventName = 'add_qso'
+        if (!qso.startAtMillis) qso.startAtMillis = (new Date()).getTime()
+        qso.startAt = new Date(qso.startAtMillis).toISOString()
+        if (qso.endAtMillis) qso.endAt = new Date(qso.endAtMillis).toISOString()
+        qso.our = qso.our || {}
+        qso.our.call = qso.our.call || ourInfo?.call
+        qso.our.operatorCall = qso.our.operatorCall || operation.local?.operatorCall
+        qso.our.sent = expandRSTValues(qso.our.sent, qso.mode)
 
-        trackEvent(eventName, { their_prefix: oneQSO.their?.entityPrefix ?? oneQSO.their?.guess?.entityPrefix, refs: (oneQSO.refs || []).map(r => r.type).join(',') })
+        qso.their = qso.their || {}
+        qso.their.sent = expandRSTValues(qso.their.sent, qso.mode)
+        // let lastUUID
+
+        const { call, allCalls } = parseStackedCalls(qso?.their?.call ?? '')
+
+        const multiQSOs = []
+
+        for (let i = 0; i < allCalls.length; i++) {
+          let oneQSO = qso
+          qso.their.call = call
+          if (allCalls.length > 1) { // If this is a multi-call QSO, we need to clone and annotate the QSO for each call
+            console.log('preclone ')
+            console.log(qso)
+            oneQSO = cloneDeep(qso)
+            console.log('postclone ')
+            console.log(oneQSO)
+            if (i > 0) oneQSO.uuid = null
+            oneQSO.their.call = allCalls[i]?.trim()
+            oneQSO.their.guess = {}
+            oneQSO.their.lookup = {}
+            oneQSO = await annotateQSO({ qso: oneQSO, online: false, settings, dispatch })
+            console.log('this here is the problem')
+            console.log(oneQSO)
+            oneQSO._needsLookup = true
+          }
+          multiQSOs.push(oneQSO)
+
+          const eventName = 'add_qso'
+
+          trackEvent(eventName, { their_prefix: oneQSO.their?.entityPrefix ?? oneQSO.their?.guess?.entityPrefix, refs: (oneQSO.refs || []).map(r => r.type).join(',') })
 
         // lastUUID = oneQSO.uuid
-      }
+        }
 
-      const activities = findHooks('activity').filter(activity => activity.processQSOBeforeSaveWithDispatch || activity.processQSOBeforeSave)
-      for (const activity of activities) {
-        for (const q of multiQSOs) {
-          if (activity.processQSOBeforeSaveWithDispatch) {
-            activity.processQSOBeforeSaveWithDispatch({ qso: q, operation, qsos, vfo, settings, dispatch })
-          } else {
-            activity.processQSOBeforeSave({ qso: q, operation, qsos, vfo, settings })
+        const activities = findHooks('activity').filter(activity => activity.processQSOBeforeSaveWithDispatch || activity.processQSOBeforeSave)
+        for (const activity of activities) {
+          for (const q of multiQSOs) {
+            if (activity.processQSOBeforeSaveWithDispatch) {
+              activity.processQSOBeforeSaveWithDispatch({ qso: q, operation, qsos, vfo, settings, dispatch })
+            } else {
+              activity.processQSOBeforeSave({ qso: q, operation, qsos, vfo, settings })
+            }
           }
         }
-      }
 
-      setTimeout(() => {
+        setTimeout(() => {
         // Add the QSO to the operation, and set a new QSO
         // But leave enough time for blur effects to take place before being overwritten by the new setQSO
         // Just 10ms did not seemed to be enough in tests, but 50ms is fine.
 
-        dispatch(addQSOs({ uuid: operation.uuid, qsos: multiQSOs }))
-        if (DEBUG) logTimer('submit', 'handleSubmit added QSOs')
+          console.log('checking multiQSOs')
+          console.log(multiQSOs)
 
-        // Let queue management decide what to do next
-        // setQSO(undefined, { otherStateChanges: { lastUUID, callStack } })
-      }, 50)
+          dispatch(addQSOs({ uuid: operation.uuid, qsos: multiQSOs }))
+          if (DEBUG) logTimer('submit', 'handleSubmit added QSOs')
+        }, 50)
 
       // if (DEBUG)
       //   logTimer('submit', 'handleSubmit after setQSO')
-    }
-  }, [dispatch, isValidQSO, operation, ourInfo?.call, qsos, route.params.qso, settings, vfo])
+      }
+    }, 0)
+  }, [dispatch, doSubmit, isValidQSO, operation, ourInfo?.call, qsos, route.params.qso, settings, vfo])
+
+  useEffect(() => {
+    handleSubmit()
+  }, [handleSubmit])
 
   return (
     <View
@@ -292,13 +307,17 @@ export default function OpSpotsModal ({ navigation, route }) {
       <Text style={[styles.fields.opName]}>{guess?.name}</Text>
       {guess?.note &&
         <>
-          <Text style={styles.fields.note}>{guess?.note}</Text>
+          <H2kMarkdown style={styles.fields.note}>{guess?.note}</H2kMarkdown>
         </>
       }
       <Text style={styles.fields.label}>{route.params.qso.spot.label}</Text>
-      <TouchableRipple style={[styles.buttons.log, { gap: 10, marginTop: 50, border: 1 }]} onPress={() => navigation.goBack()}>
+      <H2kPressable
+        style={[styles.buttons.log, { gap: 10, marginTop: 50, border: 1 }]}
+        onPress={() => navigation.goBack()}
+        rippleColor='rgba(0, 255, 255, .32)'
+      >
         <Text style={styles.fields.label}>Press here to return to spots.</Text>
-      </TouchableRipple>
+      </H2kPressable>
     </View>
   )
 }

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
@@ -1,4 +1,9 @@
-// cmw
+/*
+ * Copyright ©️ 2025 Cainan Whelchel <krinkl3@proton.me>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
 
 import { useEffect, useState, useCallback } from 'react'
 import { View, Text } from 'react-native'
@@ -303,7 +308,7 @@ export default function OpSpotsModal ({ navigation, route }) {
         fontSize: 'large'
       }] }
     >
-      <Text style={[styles.title]}>Spot Logged</Text>
+      <Text style={[styles.title]}>Log Spot?</Text>
       <Text style={[styles.fields.band]}>{route.params.qso.band} : {route.params.qso.mode} </Text>
       {/* <Text style={styles.fields.call}>{route.params.qso.their.call}{route.params.qso.their.guess.emoji}</Text> */}
       <View style={styles.fields.callAndEmoji}>

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
@@ -1,0 +1,304 @@
+// cmw
+
+import { useEffect, useState, useRef, useCallback } from 'react'
+import { View, Text, Animated } from 'react-native'
+import { TouchableRipple, ProgressBar } from 'react-native-paper'
+import { useDispatch, useSelector } from 'react-redux'
+import cloneDeep from 'clone-deep'
+
+import { parseCallsign } from '@ham2k/lib-callsigns'
+import { bandForFrequency } from '@ham2k/lib-operation-data'
+
+import { expandRSTValues, parseStackedCalls } from '../../../tools/callsignTools'
+import { annotateQSO, useCallLookup } from '../OpLoggingTab/components/LoggingPanel/useCallLookup.js'
+import { trackEvent } from '../../../distro'
+import { findHooks } from '../../../extensions/registry'
+import { addQSOs, selectQSOs } from '../../../store/qsos'
+import { logTimer } from '../../../tools/perfTools'
+// import { selectRuntimeOnline } from '../../../store/runtime'
+import { selectSettings } from '../../../store/settings'
+import { selectOperationCallInfo } from '../../../store/operations'
+import { selectVFO } from '../../../store/station/stationSlice'
+import { useThemedStyles } from '../../../styles/tools/useThemedStyles'
+
+const DEBUG = false
+
+function prepareStyles (themeStyles, themeColor) {
+  console.log(themeStyles)
+
+  const white = '#fff'
+  const black = '#000'
+  const grey = '#bbb'
+  const grey2 = '#222'
+  const grey3 = '#333'
+
+  const commonStyles = {
+    fontSize: themeStyles.normalFontSize,
+    lineHeight: themeStyles.normalFontSize * 1.3,
+    borderWidth: DEBUG ? 1 : 0,
+    color: (themeStyles.theme.dark) ? white : black
+  }
+
+  const commonButton = {
+    alignItems: 'center',
+    flex: 0,
+    justifyContent: 'center',
+    color: themeStyles.theme.colors[`on${themeColor}`]
+  }
+
+  return {
+    ...themeStyles,
+    panel: {
+      backgroundColor: themeStyles.theme.colors[`${themeColor}Container`],
+      borderBottomColor: themeStyles.theme.colors[`${themeColor}Light`],
+      borderTopColor: themeStyles.theme.colors[`${themeColor}Light`],
+      borderBottomWidth: 1,
+      paddingTop: themeStyles.oneSpace,
+      paddingBottom: themeStyles.oneSpace,
+      flexDirection: 'column',
+      color: themeStyles.theme.colors[`on${themeColor}`]
+    },
+    container: {
+      paddingHorizontal: themeStyles.oneSpace,
+      paddingTop: themeStyles.oneSpace,
+      paddingBottom: themeStyles.oneSpace,
+      gap: themeStyles.halfSpace
+    },
+    title: {
+      ...themeStyles.title,
+      color: (themeStyles.theme.dark) ? '#fff' : '#000',
+      marginBottom: 40
+    },
+    buttons: {
+      log: {
+        ...commonButton,
+        width: 200,
+        height: 175,
+        backgroundColor: themeStyles.theme.colors.tertiaryContainer,
+        borderRadius: 10
+      },
+      cancel: {
+        ...commonButton,
+        width: 200,
+        height: 175,
+        backgroundColor: (themeStyles.theme.dark) ? '#ff4444ff' : '#9f0101ff'
+      },
+      text: {
+        fontSize: themeStyles.normalFontSize * 1.3
+      }
+    },
+    fields: {
+      callAndEmoji: {
+        ...commonStyles,
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginLeft: themeStyles.oneSpace * 1.45,
+        minWidth: themeStyles.oneSpace * 5
+      },
+      call: {
+        ...commonStyles,
+        ...themeStyles.text.callsign,
+        fontWeight: 800,
+        fontSize: themeStyles.normalFontSize * 3.0,
+        lineHeight: themeStyles.normalFontSize * 2.5
+      },
+      band: {
+        ...commonStyles,
+        flex: 0,
+        marginBottom: themeStyles.oneSpace * 1
+      },
+      opName: {
+        ...commonStyles,
+        flex: 0,
+        marginBottom: themeStyles.oneSpace * 2.5,
+        fontWeight: 700,
+        fontSize: themeStyles.normalFontSize * 1.8,
+        lineHeight: themeStyles.normalFontSize * 2.5
+      },
+      note: {
+        ...commonStyles,
+        flex: 0,
+        marginBottom: themeStyles.oneSpace * 1,
+        fontWeight: 500,
+        fontSize: themeStyles.normalFontSize * 1.2,
+        color: (themeStyles.theme.dark) ? grey : grey3
+      },
+      mode: {
+        ...commonStyles,
+        flex: 0,
+        marginLeft: themeStyles.oneSpace * 0.2,
+        width: themeStyles.oneSpace * 5,
+        textAlign: 'right',
+        marginRight: themeStyles.oneSpace * 1.4,
+        color: (themeStyles.theme.dark) ? grey : grey3
+      },
+      icon: {
+        ...commonStyles,
+        flex: 0,
+        textAlign: 'left',
+        marginRight: themeStyles.oneSpace * 0.3,
+        marginLeft: themeStyles.oneSpace * -0.5,
+        marginTop: themeStyles.oneSpace * 0.2
+      },
+      label: {
+        ...commonStyles,
+        fontSize: themeStyles.normalFontSize * 1.2,
+        lineHeight: themeStyles.normalFontSize * 1.5,
+        textAlign: 'center',
+        marginTop: 10,
+        marginBottom: 10,
+        color: (themeStyles.theme.dark) ? grey : grey3
+      }
+    }
+  }
+}
+
+export default function OpSpotsModal ({ navigation, route }) {
+  const [isValidQSO, setIsValidQSO] = useState(false)
+  const themeColor = 'primary'
+  const styles = useThemedStyles(prepareStyles, themeColor)
+  const dispatch = useDispatch()
+
+  const operation = route.params.operation
+  const qsos = useSelector(state => selectQSOs(state, route.params.operation.uuid))
+  const settings = useSelector(selectSettings)
+  const ourInfo = useSelector(state => selectOperationCallInfo(state, operation?.uuid))
+  const vfo = useSelector(state => selectVFO(state))
+
+  const { call, guess, lookup, refs, status, when } = useCallLookup(route.params.qso)
+
+  //   console.log('callLookup results')
+  //   console.log([call, guess, lookup, refs, status, when])
+
+  useEffect(() => { // Validate and analyze the callsign
+    const { call } = parseStackedCalls(route.params.qso?.their?.call ?? '')
+
+    const callInfo = parseCallsign(call)
+
+    if (callInfo?.baseCall || call.indexOf('?') >= 0) {
+      setIsValidQSO(true)
+    } else {
+      setIsValidQSO(false)
+    }
+  }, [route.params.qso?.their?.call])
+
+  useEffect(() => {
+    const qso = route.params.qso
+
+    if (isValidQSO && !qso.deleted) {
+      // setCurrentSecondaryControl(undefined)
+
+      // if (qso?._isNew && qso?._manualTime && qso.startAtMillis) {
+      //   let nextManualTime = qso.startAtMillis + (60 * 1000)
+
+      //   if (qsos.length > 0) {
+      //     const diff = Math.abs(qso.startAtMillis - qsos[qsos.length - 1].startAtMillis)
+      //     if (diff >= 1000) {
+      //       nextManualTime = qso.startAtMillis + Math.min(diff, 60 * 5000)
+      //     }
+      //   }
+      //   // No need to await this one, can happen in parallel
+      //   dispatch(setOperationLocalData({ uuid: operation.uuid, _nextManualTime: nextManualTime }))
+      // }
+
+      delete qso._isNew
+      delete qso._willBeDeleted
+      delete qso.deleted
+
+      if (qso.freq) {
+        qso.band = bandForFrequency(qso.freq)
+      }
+
+      if (!qso.startAtMillis) qso.startAtMillis = (new Date()).getTime()
+      qso.startAt = new Date(qso.startAtMillis).toISOString()
+      if (qso.endAtMillis) qso.endAt = new Date(qso.endAtMillis).toISOString()
+      qso.our = qso.our || {}
+      qso.our.call = qso.our.call || ourInfo?.call
+      qso.our.operatorCall = qso.our.operatorCall || operation.local?.operatorCall
+      qso.our.sent = expandRSTValues(qso.our.sent, qso.mode)
+
+      qso.their = qso.their || {}
+      qso.their.sent = expandRSTValues(qso.their.sent, qso.mode)
+      let lastUUID
+
+      const { call, allCalls } = parseStackedCalls(qso?.their?.call ?? '')
+      const multiQSOs = []
+      for (let i = 0; i < allCalls.length; i++) {
+        let oneQSO = qso
+        qso.their.call = call
+        if (allCalls.length > 1) { // If this is a multi-call QSO, we need to clone and annotate the QSO for each call
+          oneQSO = cloneDeep(qso)
+          if (i > 0) oneQSO.uuid = null
+          oneQSO.their.call = allCalls[i]?.trim()
+          oneQSO.their.guess = {}
+          oneQSO.their.lookup = {}
+          oneQSO = annotateQSO({ qso: oneQSO, online: false, settings, dispatch })
+          oneQSO._needsLookup = true
+        }
+        multiQSOs.push(oneQSO)
+
+        const eventName = 'add_qso'
+
+        trackEvent(eventName, { their_prefix: oneQSO.their?.entityPrefix ?? oneQSO.their?.guess?.entityPrefix, refs: (oneQSO.refs || []).map(r => r.type).join(',') })
+
+        // lastUUID = oneQSO.uuid
+      }
+
+      const activities = findHooks('activity').filter(activity => activity.processQSOBeforeSaveWithDispatch || activity.processQSOBeforeSave)
+      for (const activity of activities) {
+        for (const q of multiQSOs) {
+          if (activity.processQSOBeforeSaveWithDispatch) {
+            activity.processQSOBeforeSaveWithDispatch({ qso: q, operation, qsos, vfo, settings, dispatch })
+          } else {
+            activity.processQSOBeforeSave({ qso: q, operation, qsos, vfo, settings })
+          }
+        }
+      }
+
+      setTimeout(() => {
+        // Add the QSO to the operation, and set a new QSO
+        // But leave enough time for blur effects to take place before being overwritten by the new setQSO
+        // Just 10ms did not seemed to be enough in tests, but 50ms is fine.
+
+        dispatch(addQSOs({ uuid: operation.uuid, qsos: multiQSOs }))
+        if (DEBUG) logTimer('submit', 'handleSubmit added QSOs')
+
+        // Let queue management decide what to do next
+        // setQSO(undefined, { otherStateChanges: { lastUUID, callStack } })
+      }, 50)
+
+      // if (DEBUG)
+      //   logTimer('submit', 'handleSubmit after setQSO')
+    }
+  }, [dispatch, isValidQSO, operation, ourInfo?.call, qsos, route.params.qso, settings, vfo])
+
+  return (
+    <View
+      style={ [styles.panel, {
+        flexDirection: 'column',
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+        // backgroundColor: styles.theme.colors[`${themeColor}Container`],
+        fontSize: 'large'
+      }] }
+    >
+      <Text style={[styles.title]}>Spot Logged</Text>
+      <Text style={[styles.fields.band]}>{route.params.qso.band} : {route.params.qso.mode} </Text>
+      {/* <Text style={styles.fields.call}>{route.params.qso.their.call}{route.params.qso.their.guess.emoji}</Text> */}
+      <View style={styles.fields.callAndEmoji}>
+        <Text style={[styles.fields.call]}>{route.params.qso.their?.call ?? '?'}</Text>
+      </View>
+      <Text style={[styles.fields.opName]}>{guess?.name}</Text>
+      {guess?.note &&
+        <>
+          <Text style={styles.fields.note}>{guess?.note}</Text>
+        </>
+      }
+      <Text style={styles.fields.label}>{route.params.qso.spot.label}</Text>
+      <TouchableRipple style={[styles.buttons.log, { gap: 10, marginTop: 50, border: 1 }]} onPress={() => navigation.goBack()}>
+        <Text style={styles.fields.label}>Press here to return to spots.</Text>
+      </TouchableRipple>
+    </View>
+  )
+}

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsModal.jsx
@@ -24,7 +24,7 @@ const DEBUG = false
 let submitTimeout
 
 function prepareStyles (themeStyles, themeColor) {
-  console.log(themeStyles)
+  // console.log(themeStyles)
 
   const white = '#fff'
   const black = '#000'
@@ -43,7 +43,9 @@ function prepareStyles (themeStyles, themeColor) {
     alignItems: 'center',
     flex: 0,
     justifyContent: 'center',
-    color: themeStyles.theme.colors[`on${themeColor}`]
+    borderRadius: 10,
+    borderWidth: 3,
+    borderColor: grey3
   }
 
   return {
@@ -72,19 +74,24 @@ function prepareStyles (themeStyles, themeColor) {
     buttons: {
       log: {
         ...commonButton,
-        width: 200,
+        width: 175,
         height: 175,
-        backgroundColor: themeStyles.theme.colors.tertiaryContainer,
-        borderRadius: 10
+        backgroundColor: (themeStyles.theme.dark) ? '#149c21ff' : '#25582aff'
       },
       cancel: {
         ...commonButton,
-        width: 200,
+        width: 175,
         height: 175,
-        backgroundColor: (themeStyles.theme.dark) ? '#ff4444ff' : '#9f0101ff'
+        backgroundColor: (themeStyles.theme.dark) ? '#b83202ff' : '#9f0101ff'
       },
       text: {
-        fontSize: themeStyles.normalFontSize * 1.3
+        ...commonStyles,
+        fontSize: themeStyles.normalFontSize * 1.3,
+        lineHeight: themeStyles.normalFontSize * 1.5,
+        textAlign: 'center',
+        marginTop: 10,
+        marginBottom: 10,
+        color: white
       }
     },
     fields: {
@@ -275,17 +282,16 @@ export default function OpSpotsModal ({ navigation, route }) {
 
           dispatch(addQSOs({ uuid: operation.uuid, qsos: multiQSOs }))
           if (DEBUG) logTimer('submit', 'handleSubmit added QSOs')
+
+          // logging is done at this point. we can navigate away from popup
+          navigation.goBack()
         }, 50)
 
       // if (DEBUG)
       //   logTimer('submit', 'handleSubmit after setQSO')
       }
     }, 0)
-  }, [dispatch, doSubmit, isValidQSO, operation, ourInfo?.call, qsos, route.params.qso, settings, vfo])
-
-  useEffect(() => {
-    handleSubmit()
-  }, [handleSubmit])
+  }, [dispatch, doSubmit, isValidQSO, operation, ourInfo?.call, qsos, route.params.qso, settings, vfo, navigation])
 
   return (
     <View
@@ -294,7 +300,6 @@ export default function OpSpotsModal ({ navigation, route }) {
         flex: 1,
         justifyContent: 'center',
         alignItems: 'center',
-        // backgroundColor: styles.theme.colors[`${themeColor}Container`],
         fontSize: 'large'
       }] }
     >
@@ -311,13 +316,26 @@ export default function OpSpotsModal ({ navigation, route }) {
         </>
       }
       <Text style={styles.fields.label}>{route.params.qso.spot.label}</Text>
-      <H2kPressable
-        style={[styles.buttons.log, { gap: 10, marginTop: 50, border: 1 }]}
-        onPress={() => navigation.goBack()}
-        rippleColor='rgba(0, 255, 255, .32)'
-      >
-        <Text style={styles.fields.label}>Press here to return to spots.</Text>
-      </H2kPressable>
+
+      <View flexDirection="row" gap="10">
+        <H2kPressable
+          style={[styles.buttons.log, { gap: 10, marginTop: 25, border: 1 }]}
+          onPress={() => {
+            // this triggers the log code above and navigates back to the spots list
+            handleSubmit()
+          }}
+          rippleColor='rgba(0, 255, 255, .32)'
+        >
+          <Text style={styles.buttons.text}>Log it!</Text>
+        </H2kPressable>
+        <H2kPressable
+          style={[styles.buttons.cancel, { gap: 10, marginTop: 25, border: 1 }]}
+          onPress={() => navigation.goBack()}
+          rippleColor='rgba(218, 68, 3, 0.32)'
+        >
+          <Text style={styles.buttons.text}>Cancel</Text>
+        </H2kPressable>
+      </View>
     </View>
   )
 }

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
@@ -42,7 +42,23 @@ export default function OpSpotsTab ({ navigation, route }) {
     }
   }, [navigation, route?.params, extraSpotInfoHooks, dispatch, online, settings])
 
+  const handleLongPress = useCallback(async ({ spot }) => {
+    if (spot._ourSpot) return
+
+    for (const hook of extraSpotInfoHooks) {
+      await hook.extraSpotInfo({ online, settings, dispatch, spot })
+    }
+
+    if (settings.mobileMode === true) {
+      if (route?.params?.splitView) {
+        navigation.navigate('Operation', { ...route?.params, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
+      } else {
+        navigation.navigate('OpSpotModal', { ...route?.params, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined, _forceLog: true } })
+      }
+    }
+  }, [navigation, route?.params, extraSpotInfoHooks, dispatch, online, settings])
+
   return (
-    <SpotsPanel operation={operation} qsos={qsos} sections={sections} onSelect={handleSelect} style={{ paddingBottom: safeArea.bottom, paddingRight: safeArea.right }} />
+    <SpotsPanel operation={operation} qsos={qsos} sections={sections} onSelect={handleSelect} onLongPress={handleLongPress} style={{ paddingBottom: safeArea.bottom, paddingRight: safeArea.right }} />
   )
 }

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
@@ -49,14 +49,14 @@ export default function OpSpotsTab ({ navigation, route }) {
       await hook.extraSpotInfo({ online, settings, dispatch, spot })
     }
 
-    if (settings.mobileMode === true) {
+    if (settings.bigThumbMode === true) {
       if (route?.params?.splitView) {
         navigation.navigate('Operation', { ...route?.params, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
       } else {
         navigation.navigate('OpSpotModal', { operation, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
       }
     }
-  }, [navigation, route?.params, extraSpotInfoHooks, dispatch, online, settings])
+  }, [navigation, route?.params, extraSpotInfoHooks, dispatch, online, settings, operation])
 
   return (
     <SpotsPanel operation={operation} qsos={qsos} sections={sections} onSelect={handleSelect} onLongPress={handleLongPress} style={{ paddingBottom: safeArea.bottom, paddingRight: safeArea.right }} />

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
@@ -53,7 +53,7 @@ export default function OpSpotsTab ({ navigation, route }) {
       if (route?.params?.splitView) {
         navigation.navigate('Operation', { ...route?.params, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
       } else {
-        navigation.navigate('OpSpotModal', { ...route?.params, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined, _forceLog: true } })
+        navigation.navigate('OpSpotModal', { operation, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
       }
     }
   }, [navigation, route?.params, extraSpotInfoHooks, dispatch, online, settings])

--- a/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/OpSpotsTab.jsx
@@ -49,7 +49,7 @@ export default function OpSpotsTab ({ navigation, route }) {
       await hook.extraSpotInfo({ online, settings, dispatch, spot })
     }
 
-    if (settings.bigThumbMode === true) {
+    if (settings.bigThumbsMode === true) {
       if (route?.params?.splitView) {
         navigation.navigate('Operation', { ...route?.params, qso: { ...spot, our: undefined, _suggestedKey: spot.key, key: undefined } })
       } else {

--- a/src/screens/OperationScreens/OpSpotsTab/components/BigThumbsSpotItem.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/BigThumbsSpotItem.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright ©️ 2024-2025 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2025 Cainan Whelchel <krinkl3@proton.me>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
@@ -14,12 +14,12 @@ import { fmtDateTimeRelative, prepareTimeValue } from '../../../../tools/timeFor
 import { paperNameOrHam2KIcon, H2kPressable } from '../../../../ui'
 
 /**
- * When settings Mobile Mode is true, this is used to render spots in SpotList.
+ * When Big Thumbs Mode is enabled, this is used to render spots in SpotList.
  *
  * It's the same as SpotItem but with some padding and different layout for better viewing
- * while mobile with a phone or tablet in a mounted holder.
+ * while the device is further away from the user.
  */
-const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPress, onLongPress }) {
+const BigThumbsSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPress, onLongPress }) {
   const freqParts = useMemo(() => partsForFreqInMHz(spot.freq), [spot.freq])
 
   if (spot?.their?.call === 'W8WR') spot.their.call = 'N2Y'
@@ -39,7 +39,7 @@ const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPres
         opacity: 0.6
       }
     }
-    // no band on mobile spot item
+    // no band on big thumbs spot item
     // if (spot.spot?.flags?.newBand) {
     //   workedStyles.bandStyle = {
     //     fontWeight: 'bold',
@@ -88,14 +88,14 @@ const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPres
       const diff = t2 - t1
 
       if (diff > (20 * 60 * 1000)) {
-        return styles.mobile.time.oldest
+        return styles.bigThumbs.time.oldest
       } else if (diff > (15 * 60 * 1000)) {
-        return styles.mobile.time.old
+        return styles.bigThumbs.time.old
       } else if (diff <= (2 * 60 * 1000)) {
-        return styles.mobile.time.new
+        return styles.bigThumbs.time.new
       }
     }
-    return styles.mobile.time.normal
+    return styles.bigThumbs.time.normal
   };
 
   return (
@@ -106,14 +106,14 @@ const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPres
     >
       <View style={styles.doubleRowMobileMode}>
         <View style={styles.doubleRowMobileModeLeft}>
-          <View style={[styles.mobile.freq, commonStyle]}>
+          <View style={[styles.bigThumbs.freq, commonStyle]}>
             <View>
-              <Text style={[styles.mobile.freqMHz, commonStyle]}>{freqParts[0]}</Text>
+              <Text style={[styles.bigThumbs.freqMHz, commonStyle]}>{freqParts[0]}</Text>
             </View>
             <View style={{ display: 'flex', flexDirection: 'row' }}>
-              <Text style={[styles.mobile.freqKHz, commonStyle]}>.{freqParts[1]}</Text>
+              <Text style={[styles.bigThumbs.freqKHz, commonStyle]}>.{freqParts[1]}</Text>
               {freqParts[2] !== '000' && (
-                <Text style={[styles.mobile.freqHz, commonStyle]}>.{freqParts[2]}</Text>
+                <Text style={[styles.bigThumbs.freqHz, commonStyle]}>.{freqParts[2]}</Text>
               )}
             </View>
           </View>
@@ -121,7 +121,7 @@ const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPres
         <View style={styles.doubleRowMobileModeRight}>
           <View style={styles.doubleRowInnerRowMobile}>
             <View style={styles.fields.callAndEmoji}>
-              <Text style={[styles.mobile.call, commonStyle, callStyle]}>{spot.their?.call ?? '?'}</Text>
+              <Text style={[styles.bigThumbs.call, commonStyle, callStyle]}>{spot.their?.call ?? '?'}</Text>
               {spot.their?.guess?.emoji && (
                 <Text style={[styles.fields.emoji, commonStyle, { lineHeight: 20 }]}>{spot.their?.guess?.emoji}</Text>
               )}
@@ -129,7 +129,7 @@ const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPres
             <Text style={[styles.fields.time, commonStyle, getTimeColor(spot.spot?.timeInMillis)]}>{fmtDateTimeRelative(spot.spot?.timeInMillis, { roundTo: 'minutes' })}</Text>
           </View>
           <View style={[styles.doubleRowInnerRowMobile, { marginTop: 5 }]}>
-            <Text style={[styles.mobile.mode, commonStyle, modeStyle]}>{spot.mode}</Text>
+            <Text style={[styles.bigThumbs.mode, commonStyle, modeStyle]}>{spot.mode}</Text>
             {spot.spots.filter(s => s?.icon).map(subSpot => (
               <View key={subSpot.source} style={[styles.fields.icon, commonStyle, refStyle]}>
                 <Icon
@@ -140,7 +140,7 @@ const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPres
                 />
               </View>
             ))}
-            <Text style={[styles.mobile.label, commonStyle, refStyle]} numberOfLines={1} ellipsizeMode="tail">
+            <Text style={[styles.bigThumbs.label, commonStyle, refStyle]} numberOfLines={1} ellipsizeMode="tail">
               {spot.spot.emoji}
               {spot.spot.label}
             </Text>
@@ -150,4 +150,4 @@ const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPres
     </H2kPressable>
   )
 })
-export default MobileSpotItem
+export default BigThumbsSpotItem

--- a/src/screens/OperationScreens/OpSpotsTab/components/MobileSpotItem.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/MobileSpotItem.jsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright ©️ 2024-2025 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useMemo } from 'react'
+import { Icon, Text } from 'react-native-paper'
+
+import { View } from 'react-native'
+import { partsForFreqInMHz } from '../../../../tools/frequencyFormats'
+import { fmtDateTimeRelative, prepareTimeValue } from '../../../../tools/timeFormats'
+import { paperNameOrHam2KIcon, H2kPressable } from '../../../../ui'
+
+/**
+ * When settings Mobile Mode is true, this is used to render spots in SpotList.
+ *
+ * It's the same as SpotItem but with some padding and different layout for better viewing
+ * while mobile with a phone or tablet in a mounted holder.
+ */
+const MobileSpotItem = React.memo(function QSOItemMobile ({ spot, styles, onPress, onLongPress }) {
+  const freqParts = useMemo(() => partsForFreqInMHz(spot.freq), [spot.freq])
+
+  if (spot?.their?.call === 'W8WR') spot.their.call = 'N2Y'
+
+  const { commonStyle, modeStyle, refStyle, callStyle } = useMemo(() => {
+    const workedStyles = {}
+    if (spot.spot?.type === 'self') {
+      workedStyles.commonStyle = {
+        color: styles.colors.tertiary,
+        opacity: 0.7
+      }
+    }
+    if (spot.spot?.type === 'duplicate') {
+      workedStyles.commonStyle = {
+        textDecorationLine: 'line-through',
+        textDecorationColor: styles.colors.onBackground,
+        opacity: 0.6
+      }
+    }
+    // no band on mobile spot item
+    // if (spot.spot?.flags?.newBand) {
+    //   workedStyles.bandStyle = {
+    //     fontWeight: 'bold',
+    //     color: styles.colors.important
+    //   }
+    // }
+    if (spot.spot?.flags?.newMode) {
+      workedStyles.modeStyle = {
+        fontWeight: 'bold',
+        color: styles.colors.important
+      }
+    }
+    if (spot.spot?.flags?.specialCall) {
+      workedStyles.callStyle = {
+        color: styles.colors.bands['40m']
+      }
+      workedStyles.refStyle = {
+        color: styles.colors.bands['40m']
+      }
+    }
+    if (spot.spot?.flags?.newRef || spot.spot?.flags?.newDay) {
+      workedStyles.refStyle = {
+        fontWeight: 'bold',
+        color: styles.colors.important
+      }
+    }
+    if (spot.spot?.flags?.newMult) {
+      workedStyles.callStyle = {
+        fontWeight: 'bold',
+        color: styles.colors.bands['10m']
+      }
+      workedStyles.refStyle = {
+        fontWeight: 'bold',
+        color: styles.colors.bands['10m']
+      }
+    }
+
+    return workedStyles
+  }, [spot, styles])
+
+  function getTimeColor (millis) {
+    const t1 = prepareTimeValue(millis)
+    const t2 = prepareTimeValue(new Date())
+
+    if (t1 && t2) {
+      const diff = t2 - t1
+
+      if (diff > (20 * 60 * 1000)) {
+        return styles.mobile.time.oldest
+      } else if (diff > (15 * 60 * 1000)) {
+        return styles.mobile.time.old
+      } else if (diff <= (2 * 60 * 1000)) {
+        return styles.mobile.time.new
+      }
+    }
+    return styles.mobile.time.normal
+  };
+
+  return (
+    <H2kPressable
+      onPress={() => onPress && onPress({ spot })}
+      onLongPress={() => onLongPress && onLongPress({ spot })}
+      rippleColor='rgba(0, 255, 255, .32)'
+    >
+      <View style={styles.doubleRowMobileMode}>
+        <View style={styles.doubleRowMobileModeLeft}>
+          <View style={[styles.mobile.freq, commonStyle]}>
+            <View>
+              <Text style={[styles.mobile.freqMHz, commonStyle]}>{freqParts[0]}</Text>
+            </View>
+            <View style={{ display: 'flex', flexDirection: 'row' }}>
+              <Text style={[styles.mobile.freqKHz, commonStyle]}>.{freqParts[1]}</Text>
+              {freqParts[2] !== '000' && (
+                <Text style={[styles.mobile.freqHz, commonStyle]}>.{freqParts[2]}</Text>
+              )}
+            </View>
+          </View>
+        </View>
+        <View style={styles.doubleRowMobileModeRight}>
+          <View style={styles.doubleRowInnerRowMobile}>
+            <View style={styles.fields.callAndEmoji}>
+              <Text style={[styles.mobile.call, commonStyle, callStyle]}>{spot.their?.call ?? '?'}</Text>
+              {spot.their?.guess?.emoji && (
+                <Text style={[styles.fields.emoji, commonStyle, { lineHeight: 20 }]}>{spot.their?.guess?.emoji}</Text>
+              )}
+            </View>
+            <Text style={[styles.fields.time, commonStyle, getTimeColor(spot.spot?.timeInMillis)]}>{fmtDateTimeRelative(spot.spot?.timeInMillis, { roundTo: 'minutes' })}</Text>
+          </View>
+          <View style={[styles.doubleRowInnerRowMobile, { marginTop: 5 }]}>
+            <Text style={[styles.mobile.mode, commonStyle, modeStyle]}>{spot.mode}</Text>
+            {spot.spots.filter(s => s?.icon).map(subSpot => (
+              <View key={subSpot.source} style={[styles.fields.icon, commonStyle, refStyle]}>
+                <Icon
+                  key={subSpot.source}
+                  source={paperNameOrHam2KIcon(subSpot.icon)}
+                  size={styles.oneSpace * 2.3}
+                  color={(subSpot?.type === 'scoring' && refStyle?.color) || commonStyle?.color}
+                />
+              </View>
+            ))}
+            <Text style={[styles.mobile.label, commonStyle, refStyle]} numberOfLines={1} ellipsizeMode="tail">
+              {spot.spot.emoji}
+              {spot.spot.label}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </H2kPressable>
+  )
+})
+export default MobileSpotItem

--- a/src/screens/OperationScreens/OpSpotsTab/components/SpotItem.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/SpotItem.jsx
@@ -10,13 +10,13 @@ import { Icon, Text } from 'react-native-paper'
 
 import { View } from 'react-native'
 import { partsForFreqInMHz } from '../../../../tools/frequencyFormats'
-import { fmtDateTimeRelative, prepareTimeValue } from '../../../../tools/timeFormats'
+import { fmtDateTimeRelative } from '../../../../tools/timeFormats'
 import { paperNameOrHam2KIcon, H2kPressable } from '../../../../ui'
 
 export function guessItemHeight (qso, styles) {
   return styles.doubleRow.height + styles.doubleRow.borderBottomWidth
 }
-const SpotItem = React.memo(function QSOItem ({ spot, onPress, styles, extendedWidth, onLongPress, settings }) {
+const SpotItem = React.memo(function QSOItem ({ spot, onPress, styles, extendedWidth, settings }) {
   const freqParts = useMemo(() => partsForFreqInMHz(spot.freq), [spot.freq])
 
   if (spot?.their?.call === 'W8WR') spot.their.call = 'N2Y'
@@ -76,120 +76,51 @@ const SpotItem = React.memo(function QSOItem ({ spot, onPress, styles, extendedW
     return workedStyles
   }, [spot, styles])
 
-  function getTimeColor (millis) {
-    const t1 = prepareTimeValue(millis)
-    const t2 = prepareTimeValue(new Date())
-
-    if (t1 && t2) {
-      const diff = t2 - t1
-
-      if (diff > (20 * 60 * 1000)) {
-        return styles.mobile.time.oldest
-      } else if (diff > (15 * 60 * 1000)) {
-        return styles.mobile.time.old
-      } else if (diff <= (2 * 60 * 1000)) {
-        return styles.mobile.time.new
-      }
-    }
-    return styles.mobile.time.normal
-  };
-
   return (
     <H2kPressable
       onPress={() => onPress && onPress({ spot })}
-      onLongPress={() => onLongPress && onLongPress({ spot })}
-      // rippleColor="rgba(0, 255, 255, .32)"
-      rippleColor={ (settings.mobileMode === true) ? 'rgba(0, 255, 255, .32)' : '' }
-    //   background={{
-    //     color: 'rgba(0, 255, 255, .32)',
-    //     foreground: true
-    //   }}
     >
-      {settings.mobileMode === true ? (
-        <View style={styles.doubleRowMobileMode}>
-          <View style={styles.doubleRowMobileModeLeft}>
-            <View style={[styles.mobile.freq, commonStyle]}>
-              <View>
-                <Text style={[styles.mobile.freqMHz, commonStyle]}>{freqParts[0]}</Text>
-              </View>
-              <View style={{ display: 'flex', flexDirection: 'row' }}>
-                <Text style={[styles.mobile.freqKHz, commonStyle]}>.{freqParts[1]}</Text>
-                <Text style={[styles.mobile.freqHz, commonStyle]}>.{freqParts[2]}</Text>
-              </View>
-            </View>
+      <View style={styles.doubleRow}>
+        <View style={styles.doubleRowInnerRow}>
+          <Text style={[styles.fields.freq, commonStyle]}>
+            {freqParts[0] && (
+              <Text style={[styles.fields.freqMHz, commonStyle]}>{freqParts[0]}</Text>
+            )}
+            {freqParts[1] && (
+              <Text style={[styles.fields.freqKHz, commonStyle]}>.{freqParts[1]}</Text>
+            )}
+            {freqParts[2] && (
+              <Text style={[styles.fields.freqHz, commonStyle]}>.{freqParts[2]}</Text>
+            )}
+          </Text>
+          <View style={styles.fields.callAndEmoji}>
+            <Text style={[styles.fields.call, commonStyle, callStyle]}>{spot.their?.call ?? '?'}</Text>
+            {spot.their?.guess?.emoji && (
+              <Text style={[styles.fields.emoji, commonStyle, { lineHeight: 20 }]}>{spot.their?.guess?.emoji}</Text>
+            )}
+            <Text style={[styles.fields.label, commonStyle, callStyle, { marginLeft: styles.oneSpace }]}>{spot.spot.callLabel ?? ''}</Text>
           </View>
-          <View style={styles.doubleRowMobileModeRight}>
-            <View style={styles.doubleRowInnerRowMobile}>
-              <View style={styles.fields.callAndEmoji}>
-                <Text style={[styles.mobile.call, commonStyle]}>{spot.their?.call ?? '?'}</Text>
-                {spot.their?.guess?.emoji && (
-                  <Text style={[styles.fields.emoji, commonStyle, { lineHeight: 20 }]}>{spot.their?.guess?.emoji}</Text>
-                )}
-              </View>
-              <Text style={[styles.fields.time, commonStyle, getTimeColor(spot.spot?.timeInMillis)]}>{fmtDateTimeRelative(spot.spot?.timeInMillis, { roundTo: 'minutes' })}</Text>
-            </View>
-            <View style={[styles.doubleRowInnerRowMobile, { marginTop: 5 }]}>
-              <Text style={[styles.mobile.mode, commonStyle, modeStyle]}>{spot.mode}</Text>
-              {spot.spots.filter(s => s?.icon).map(subSpot => (
-                <View key={subSpot.source} style={[styles.fields.icon, commonStyle, refStyle]}>
-                  <Icon
-                    key={subSpot.source}
-                    source={paperNameOrHam2KIcon(subSpot.icon)}
-                    size={styles.oneSpace * 2.3}
-                    color={(subSpot?.type === 'scoring' && refStyle?.color) || commonStyle?.color}
-                  />
-                </View>
-              ))}
-              <Text style={[styles.mobile.label, commonStyle, refStyle]} numberOfLines={1} ellipsizeMode="tail">
-                {spot.spot.emoji}
-                {spot.spot.label}
-              </Text>
-            </View>
-          </View>
+          <Text style={[styles.fields.time, commonStyle]}>{fmtDateTimeRelative(spot.spot?.timeInMillis, { roundTo: 'minutes' })}</Text>
         </View>
-      ) : (
-        <View style={styles.doubleRow}>
-          <View style={styles.doubleRowInnerRow}>
-            <Text style={[styles.fields.freq, commonStyle]}>
-              {freqParts[0] && (
-                <Text style={[styles.fields.freqMHz, commonStyle]}>{freqParts[0]}</Text>
-              )}
-              {freqParts[1] && (
-                <Text style={[styles.fields.freqKHz, commonStyle]}>.{freqParts[1]}</Text>
-              )}
-              {freqParts[2] && (
-                <Text style={[styles.fields.freqHz, commonStyle]}>.{freqParts[2]}</Text>
-              )}
-            </Text>
-            <View style={styles.fields.callAndEmoji}>
-              <Text style={[styles.fields.call, commonStyle, callStyle]}>{spot.their?.call ?? '?'}</Text>
-              {spot.their?.guess?.emoji && (
-                <Text style={[styles.fields.emoji, commonStyle, { lineHeight: 20 }]}>{spot.their?.guess?.emoji}</Text>
-              )}
-              <Text style={[styles.fields.label, commonStyle, callStyle, { marginLeft: styles.oneSpace }]}>{spot.spot.callLabel ?? ''}</Text>
+        <View style={styles.doubleRowInnerRow}>
+          <Text style={[styles.fields.band, commonStyle, bandStyle]}>{spot.band}</Text>
+          <Text style={[styles.fields.mode, commonStyle, modeStyle]}>{spot.mode}</Text>
+          {spot.spots.filter(s => s?.icon).map(subSpot => (
+            <View key={subSpot.subSource ?? subSpot.source} style={[styles.fields.icon, commonStyle, refStyle]}>
+              <Icon
+                key={subSpot.subSource ?? subSpot.source}
+                source={paperNameOrHam2KIcon(subSpot.icon)}
+                size={styles.oneSpace * 2.3}
+                color={(subSpot?.type === 'scoring' && refStyle?.color) || commonStyle?.color}
+              />
             </View>
-            <Text style={[styles.fields.time, commonStyle]}>{fmtDateTimeRelative(spot.spot?.timeInMillis, { roundTo: 'minutes' })}</Text>
-          </View>
-          <View style={styles.doubleRowInnerRow}>
-            <Text style={[styles.fields.band, commonStyle, bandStyle]}>{spot.band}</Text>
-            <Text style={[styles.fields.mode, commonStyle, modeStyle]}>{spot.mode}</Text>
-            {spot.spots.filter(s => s?.icon).map(subSpot => (
-              <View key={subSpot.subSource ?? subSpot.source} style={[styles.fields.icon, commonStyle, refStyle]}>
-                <Icon
-                  key={subSpot.subSource ?? subSpot.source}
-                  source={paperNameOrHam2KIcon(subSpot.icon)}
-                  size={styles.oneSpace * 2.3}
-                  color={(subSpot?.type === 'scoring' && refStyle?.color) || commonStyle?.color}
-                />
-              </View>
-            ))}
-            <Text style={[styles.fields.label, commonStyle, refStyle]} numberOfLines={1} ellipsizeMode="tail">
-              {spot.spot.emoji}
-              {spot.spot.label}
-            </Text>
-          </View>
+          ))}
+          <Text style={[styles.fields.label, commonStyle, refStyle]} numberOfLines={1} ellipsizeMode="tail">
+            {spot.spot.emoji}
+            {spot.spot.label}
+          </Text>
         </View>
-      )}
+      </View>
     </H2kPressable>
   )
 })

--- a/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
@@ -43,7 +43,7 @@ export default function SpotList ({ sections, loading, refresh, style, onPress, 
   const renderRow = useCallback(({ item, index }) => {
     const spot = item
     return (
-      (settings.mobileMode ? (
+      (settings.bigThumbMode ? (
         <MobileSpotItem key={spot.key} spot={spot} onPress={onPress} onLongPress={onLongPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
       ) : (
         <SpotItem key={spot.key} spot={spot} onPress={onPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />

--- a/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
@@ -14,7 +14,7 @@ import getItemLayout from 'react-native-get-item-layout-section-list'
 
 import { useThemedStyles } from '../../../../styles/tools/useThemedStyles'
 import SpotItem from './SpotItem'
-import MobileSpotItem from './MobileSpotItem'
+import BigThumbsSpotItem from './BigThumbsSpotItem'
 import SpotHeader from './SpotHeader'
 
 export default function SpotList ({ sections, loading, refresh, style, onPress, onLongPress, settings }) {
@@ -43,8 +43,8 @@ export default function SpotList ({ sections, loading, refresh, style, onPress, 
   const renderRow = useCallback(({ item, index }) => {
     const spot = item
     return (
-      (settings.bigThumbMode ? (
-        <MobileSpotItem key={spot.key} spot={spot} onPress={onPress} onLongPress={onLongPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
+      (settings.bigThumbsMode ? (
+        <BigThumbsSpotItem key={spot.key} spot={spot} onPress={onPress} onLongPress={onLongPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
       ) : (
         <SpotItem key={spot.key} spot={spot} onPress={onPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
       )
@@ -94,7 +94,7 @@ function _prepareStyles (themeStyles, style, deviceColorScheme) {
     borderWidth: DEBUG ? 1 : 0
   }
 
-  const mobileStyles = {
+  const bigThumbsStyles = {
     fontSize: themeStyles.normalFontSize * 1.2,
     lineHeight: themeStyles.normalFontSize * 1.5,
     borderWidth: 0 // debug
@@ -119,9 +119,9 @@ function _prepareStyles (themeStyles, style, deviceColorScheme) {
       paddingRight: 0,
       justifyContent: 'center'
     },
-    mobile: {
+    bigThumbs: {
       freq: {
-        ...mobileStyles,
+        ...bigThumbsStyles,
         ...themeStyles.text.numbers,
         ...themeStyles.text.lighter,
         flexDirection: 'column',
@@ -130,24 +130,24 @@ function _prepareStyles (themeStyles, style, deviceColorScheme) {
         alignItems: 'center'
       },
       freqMHz: {
-        ...mobileStyles,
+        ...bigThumbsStyles,
         fontWeight: '600',
         textAlign: 'right',
         fontSize: themeStyles.normalFontSize * 1.0
       },
       freqKHz: {
-        ...mobileStyles,
+        ...bigThumbsStyles,
         textAlign: 'right',
         fontWeight: '700'
       },
       freqHz: {
-        ...mobileStyles,
+        ...bigThumbsStyles,
         fontWeight: '600',
         textAlign: 'right',
         fontSize: themeStyles.normalFontSize
       },
       call: {
-        ...mobileStyles
+        ...bigThumbsStyles
       },
       label: {
         flex: 1,

--- a/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
@@ -14,6 +14,7 @@ import getItemLayout from 'react-native-get-item-layout-section-list'
 
 import { useThemedStyles } from '../../../../styles/tools/useThemedStyles'
 import SpotItem from './SpotItem'
+import MobileSpotItem from './MobileSpotItem'
 import SpotHeader from './SpotHeader'
 
 export default function SpotList ({ sections, loading, refresh, style, onPress, onLongPress, settings }) {
@@ -42,7 +43,12 @@ export default function SpotList ({ sections, loading, refresh, style, onPress, 
   const renderRow = useCallback(({ item, index }) => {
     const spot = item
     return (
-      <SpotItem key={spot.key} spot={spot} onPress={onPress} onLongPress={onLongPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
+      (settings.mobileMode ? (
+        <MobileSpotItem key={spot.key} spot={spot} onPress={onPress} onLongPress={onLongPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
+      ) : (
+        <SpotItem key={spot.key} spot={spot} onPress={onPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
+      )
+      )
     )
   }, [onPress, onLongPress, styles, paddingRight, paddingLeft, extendedWidth, settings])
 
@@ -144,6 +150,7 @@ function _prepareStyles (themeStyles, style, deviceColorScheme) {
         ...mobileStyles
       },
       label: {
+        flex: 1,
         fontSize: themeStyles.normalFontSize * 0.9
       },
       mode: {

--- a/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/SpotList.jsx
@@ -16,7 +16,7 @@ import { useThemedStyles } from '../../../../styles/tools/useThemedStyles'
 import SpotItem from './SpotItem'
 import SpotHeader from './SpotHeader'
 
-export default function SpotList ({ sections, loading, refresh, style, onPress }) {
+export default function SpotList ({ sections, loading, refresh, style, onPress, onLongPress, settings }) {
   const styles = useThemedStyles(_prepareStyles, style)
 
   const safeArea = useSafeAreaInsets()
@@ -42,9 +42,9 @@ export default function SpotList ({ sections, loading, refresh, style, onPress }
   const renderRow = useCallback(({ item, index }) => {
     const spot = item
     return (
-      <SpotItem key={spot.key} spot={spot} onPress={onPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} />
+      <SpotItem key={spot.key} spot={spot} onPress={onPress} onLongPress={onLongPress} styles={styles} style={{ paddingRight, paddingLeft }} extendedWidth={extendedWidth} settings={settings} />
     )
-  }, [styles, onPress, extendedWidth, paddingRight, paddingLeft])
+  }, [onPress, onLongPress, styles, paddingRight, paddingLeft, extendedWidth, settings])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const calculateLayout = useCallback(
@@ -79,7 +79,7 @@ export default function SpotList ({ sections, loading, refresh, style, onPress }
   )
 }
 
-function _prepareStyles (themeStyles, style) {
+function _prepareStyles (themeStyles, style, deviceColorScheme) {
   const DEBUG = false
 
   const commonStyles = {
@@ -87,6 +87,16 @@ function _prepareStyles (themeStyles, style) {
     lineHeight: themeStyles.normalFontSize * 1.3,
     borderWidth: DEBUG ? 1 : 0
   }
+
+  const mobileStyles = {
+    fontSize: themeStyles.normalFontSize * 1.2,
+    lineHeight: themeStyles.normalFontSize * 1.5,
+    borderWidth: 0 // debug
+  }
+
+  //   console.log(themeStyles)
+  //   console.log(style)
+  //   console.log(deviceColorScheme)
 
   return {
     ...themeStyles,
@@ -102,6 +112,62 @@ function _prepareStyles (themeStyles, style) {
       paddingLeft: 0,
       paddingRight: 0,
       justifyContent: 'center'
+    },
+    mobile: {
+      freq: {
+        ...mobileStyles,
+        ...themeStyles.text.numbers,
+        ...themeStyles.text.lighter,
+        flexDirection: 'column',
+        width: themeStyles.oneSpace * 11.15,
+        textAlign: 'center',
+        alignItems: 'center'
+      },
+      freqMHz: {
+        ...mobileStyles,
+        fontWeight: '600',
+        textAlign: 'right',
+        fontSize: themeStyles.normalFontSize * 1.0
+      },
+      freqKHz: {
+        ...mobileStyles,
+        textAlign: 'right',
+        fontWeight: '700'
+      },
+      freqHz: {
+        ...mobileStyles,
+        fontWeight: '600',
+        textAlign: 'right',
+        fontSize: themeStyles.normalFontSize
+      },
+      call: {
+        ...mobileStyles
+      },
+      label: {
+        fontSize: themeStyles.normalFontSize * 0.9
+      },
+      mode: {
+        fontSize: themeStyles.normalFontSize * 0.9,
+        flex: 0,
+        marginLeft: themeStyles.oneSpace * 0.5,
+        width: themeStyles.oneSpace * 4,
+        textAlign: 'right',
+        marginRight: themeStyles.oneSpace * 1.0
+      },
+      time: {
+        oldest: {
+          color: (themeStyles.theme.dark) ? '#f11818ff' : '#e70606ff'
+        },
+        old: {
+          color: (themeStyles.theme.dark) ? '#ff733fff' : '#9a4e0cff'
+        },
+        normal: {
+          color: (themeStyles.theme.dark) ? '#CCC' : '#222'
+        },
+        new: {
+          color: (themeStyles.theme.dark) ? '#11dda0ff' : '#128700ff'
+        }
+      }
     },
     fields: {
       freq: {

--- a/src/screens/OperationScreens/OpSpotsTab/components/SpotsPanel.jsx
+++ b/src/screens/OperationScreens/OpSpotsTab/components/SpotsPanel.jsx
@@ -66,7 +66,7 @@ function prepareStyles (baseStyles, themeColor, style) {
   }
 }
 
-export default function SpotsPanel ({ operation, qsos, sections, onSelect, style }) {
+export default function SpotsPanel ({ operation, qsos, sections, onSelect, style, onLongPress }) {
   const themeColor = 'tertiary'
   const styles = useThemedStyles(prepareStyles, themeColor, style)
 
@@ -316,6 +316,10 @@ export default function SpotsPanel ({ operation, qsos, sections, onSelect, style
     onSelect && onSelect({ spot })
   }, [onSelect])
 
+  const handleLongPress = useCallback(({ spot }) => {
+    onLongPress && onLongPress({ spot })
+  }, [onLongPress])
+
   return (
     <GestureHandlerRootView style={[{ flex: 1, flexDirection: 'column', alignItems: 'stretch' }]}>
       {showControls ? (
@@ -375,6 +379,8 @@ export default function SpotsPanel ({ operation, qsos, sections, onSelect, style
             loading={spotsState.loading}
             refresh={refresh}
             onPress={handlePress}
+            onLongPress={handleLongPress}
+            settings={settings}
             style={{
               paddingBottom: style?.paddingBottom,
               paddingRight: style?.paddingRight,

--- a/src/screens/SettingsScreens/screens/CreditsSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/CreditsSettingsScreen.jsx
@@ -120,6 +120,12 @@ export default function CreditsSettingsScreen ({ navigation, splitView }) {
             leftIcon="account"
             onPress={() => navigation.navigate('CallInfo', { call: 'W8NI' })}
           />
+          <H2kListItem
+            title={'Cainan • N9FZ'}
+            description={'Code: Big thumbs mode.'}
+            leftIcon="account"
+            onPress={() => navigation.navigate('CallInfo', { call: 'N9FZ' })}
+          />
         </H2kListSection>
         <View style={{ height: safeAreaInsets.bottom }} />
 

--- a/src/screens/SettingsScreens/screens/LoggingSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/LoggingSettingsScreen.jsx
@@ -55,14 +55,15 @@ export default function LoggingSettingsScreen ({ navigation, splitView }) {
             onPress={() => dispatch(setSettings({ leftieMode: !settings.leftieMode }))}
           />
 
-          <H2kListItem title={'Big Thumb Mode'}
-            description={settings.bigThumbMode ? 'Use big thumb mode: log from spots list with a long press' : 'Use normal logging' }
-            leftIcon="thumb-up-outline"
-            rightSwitchValue={!!settings.bigThumbMode}
-            rightSwitchOnValueChange={(value) => dispatch(setSettings({ bigThumbMode: value }))}
-            onPress={() => dispatch(setSettings({ bigThumbMode: !settings.bigThumbMode }))}
-          />
-
+          {settings.devMode && (
+            <H2kListItem title={'Big Thumbs Mode'}
+              description={settings.bigThumbsMode ? 'Use big thumbs mode: log from spots list with a long press' : 'Use normal logging' }
+              leftIcon="thumb-up-outline"
+              rightSwitchValue={!!settings.bigThumbsMode}
+              rightSwitchOnValueChange={(value) => dispatch(setSettings({ bigThumbsMode: value }))}
+              onPress={() => dispatch(setSettings({ bigThumbMode: !settings.bigThumbsMode }))}
+            />
+          )}
           <H2kListItem title={'Country Flags'}
             description={{ none: "Don't show any flags", all: 'Show flags for all contacts' }[settings.dxFlags] || 'Show only for DX contacts'}
             leftIcon="flag"

--- a/src/screens/SettingsScreens/screens/LoggingSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/LoggingSettingsScreen.jsx
@@ -55,6 +55,14 @@ export default function LoggingSettingsScreen ({ navigation, splitView }) {
             onPress={() => dispatch(setSettings({ leftieMode: !settings.leftieMode }))}
           />
 
+          <H2kListItem title={'Big Thumb Mode'}
+            description={settings.bigThumbMode ? 'Use big thumb mode: log from spots list with a long press' : 'Use normal logging' }
+            leftIcon="thumb-up-outline"
+            rightSwitchValue={!!settings.bigThumbMode}
+            rightSwitchOnValueChange={(value) => dispatch(setSettings({ bigThumbMode: value }))}
+            onPress={() => dispatch(setSettings({ bigThumbMode: !settings.bigThumbMode }))}
+          />
+
           <H2kListItem title={'Country Flags'}
             description={{ none: "Don't show any flags", all: 'Show flags for all contacts' }[settings.dxFlags] || 'Show only for DX contacts'}
             leftIcon="flag"
@@ -101,14 +109,6 @@ export default function LoggingSettingsScreen ({ navigation, splitView }) {
             rightSwitchValue={!!settings.jumpAfterRST}
             rightSwitchOnValueChange={(value) => dispatch(setSettings({ jumpAfterRST: value }))}
             onPress={() => dispatch(setSettings({ jumpAfterRST: !settings.jumpAfterRST }))}
-          />
-
-          <H2kListItem title={'Mobile Mode'}
-            description={settings.mobileMode ? 'Use mobile logging' : 'Use default logging' }
-            leftIcon="car"
-            rightSwitchValue={!!settings.mobileMode}
-            rightSwitchOnValueChange={(value) => dispatch(setSettings({ mobileMode: value }))}
-            onPress={() => dispatch(setSettings({ mobileMode: !settings.mobileMode }))}
           />
 
           <H2kListItem

--- a/src/screens/SettingsScreens/screens/LoggingSettingsScreen.jsx
+++ b/src/screens/SettingsScreens/screens/LoggingSettingsScreen.jsx
@@ -68,6 +68,7 @@ export default function LoggingSettingsScreen ({ navigation, splitView }) {
               onDialogDone={() => setCurrentDialog('')}
             />
           )}
+
           <H2kListItem title={'State Field'}
             description={settings.showStateField ? 'Include State field in main exchange' : "Don't include State field" }
             leftIcon="select-marker"
@@ -100,6 +101,14 @@ export default function LoggingSettingsScreen ({ navigation, splitView }) {
             rightSwitchValue={!!settings.jumpAfterRST}
             rightSwitchOnValueChange={(value) => dispatch(setSettings({ jumpAfterRST: value }))}
             onPress={() => dispatch(setSettings({ jumpAfterRST: !settings.jumpAfterRST }))}
+          />
+
+          <H2kListItem title={'Mobile Mode'}
+            description={settings.mobileMode ? 'Use mobile logging' : 'Use default logging' }
+            leftIcon="car"
+            rightSwitchValue={!!settings.mobileMode}
+            rightSwitchOnValueChange={(value) => dispatch(setSettings({ mobileMode: value }))}
+            onPress={() => dispatch(setSettings({ mobileMode: !settings.mobileMode }))}
           />
 
           <H2kListItem

--- a/src/styles/globalStyles.js
+++ b/src/styles/globalStyles.js
@@ -134,11 +134,39 @@ export const prepareGlobalStyles = ({ theme, colorScheme, width, height }) => {
       justifyContent: 'space-between',
       width: '100%'
     },
+    doubleRowMobileMode: {
+      height: oneSpace * 10,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.outline,
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      width: '100%',
+    },
     doubleRowInnerRow: {
       // borderWidth: 1,
       height: oneSpace * 2.6,
       flexDirection: 'row',
       width: '100%'
+    },
+    doubleRowInnerRowMobile: {
+      //borderWidth: 1,
+      height: oneSpace * 2.8,
+      flexDirection: 'row',
+      width: '80%'
+    },
+    doubleRowMobileModeLeft: {
+      //borderWidth: 1,
+      height: '100%',
+      flexDirection: 'row',
+      width:'20%',
+      alignItems: 'center'
+    },
+    doubleRowMobileModeRight: {
+      //borderWidth: 1,
+      height: '100%',
+      flexDirection: 'column',
+      width:'100%',
+      justifyContent: 'center'
     },
     rowText: {
       fontSize: normalFontSize,


### PR DESCRIPTION
Mobile mode is intended to be used by hunters for logging spots (POTA, SOTA, etc) while mobile (/M) with their device in phone mount or other similar contraption. At least that's how I've been using this. And my goal was to reduce the number of touches needed to log a spot and make it easier to read from a few feet away on a phone screen

### Changes:
Adds a Logging setting to turn on Mobile Mode.

Add ability to log from long pressing a spot in the spot list. 
  - Popup appears with lookup info (only one large button here to go back but user could also navigate back by swiping)

Also formats the spots in the list to make it easier to read at a quick glance by doing the following:
  - Increase spot item row height
  - Increase font sizes
  - Removes band display
  - changes freq display: makes display multi-line and also removes Hertz display if it's 0
  - colors the spot age value: green if age <2min, orange if age >15m and red if age >20m

### Possible issues

I did nothing with the splitview mode as I don't have a tablet nor am I going to log mobile using such a device. The changes shouldn't use the new log popup when in that mode but I can not verify.

Not tested on IOS

### Screenshots
These are in dark mode but the changes use theme colors so should look OK on light mode. Recorded in emulator so its sluggish.

![settings](https://github.com/user-attachments/assets/37f00e10-4290-4580-80b0-0629af1fa3c3)

Logging by long pressing. 

![logging](https://github.com/user-attachments/assets/27ec5e42-dfbc-47d0-87d6-ab20bc14d729)

example of the lookups that got cut off in other gif:

![lookups](https://github.com/user-attachments/assets/eda25783-39f9-4c50-bb23-1db69c6090b3)

