### PR TITLE
Add upload services hook for SOTA and WWBOTA

### DIFF
--- a/RELEASE-NOTES.json
+++ b/RELEASE-NOTES.json
@@ -6,7 +6,8 @@
       "Towers on the Air (TOTA)",
       "ParksnPeaks Spotting (by M1SDH)",
       "Performance and stability improvements",
-      "Assorted bug fixes"
+      "Assorted bug fixes",
+      "Add operation upload/QSL services for SOTA and WWBOTA (by M1SDH)"
     ]
   },
   "25.12.8": {

--- a/src/extensions/activities/sota/SOTAExtension.js
+++ b/src/extensions/activities/sota/SOTAExtension.js
@@ -5,7 +5,7 @@
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import { Alert } from 'react-native'
-import { bandForFrequency } from '@ham2k/lib-operation-data'
+import { ADIF_MODE_FOR_SUBMODE, bandForFrequency } from '@ham2k/lib-operation-data'
 import { parseCallsign } from '@ham2k/lib-callsigns'
 import { annotateFromCountryFile } from '@ham2k/lib-country-files'
 import { gridToLocation } from '@ham2k/lib-maidenhead-grid'
@@ -17,6 +17,8 @@ import { filterRefs, findRef, refsToString } from '../../../tools/refTools'
 import { apiSOTA } from '../../../store/apis/apiSOTA'
 import { LOCATION_ACCURACY } from '../../constants'
 import { distanceOnEarth } from '../../../tools/geoTools'
+import { setOperationData } from '../../../store/operations'
+import { hashCode } from '../../../tools/hashCode'
 
 import { SOTAActivityOptions } from './SOTAActivityOptions'
 import { registerSOTADataFile, sotaFindAllByLocation, sotaFindOneByReference } from './SOTADataFile'
@@ -44,6 +46,7 @@ const Extension = {
         SettingItem: SOTAAccountSetting
       }
     })
+    registerHook('qsl', { hook: QSLHook })
 
     registerSOTADataFile()
     await dispatch(loadDataFile('sota-all-summits', { noticesInsteadOfFetch: true }))
@@ -180,6 +183,147 @@ const SpotsHook = {
     })
 
     return qsos
+  }
+}
+
+function sotaQsoDataStr(qso, operation) {
+  return [qso.key, qso.notes, qso.their?.grid || '', qso.our?.grid || operation?.grid || '', ...filterRefs(qso.refs, Info.huntingType).map(r => r.ref).sort()].join('|')
+}
+
+function fmtSOTADate(date) {
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const y = date.getUTCFullYear();
+  return `${d}/${m}/${y}`;
+}
+
+function fmtSotaTime(date) {
+  const h = String(date.getUTCHours()).padStart(2, '0');
+  const m = String(date.getUTCMinutes()).padStart(2, '0');
+  return `${h}${m}`;
+}
+
+const QSLHook = {
+  ...Info,
+  serviceName: 'SOTA Data',
+  canSendOutgoingQSLs: ({ operation, qsos, settings }) => {
+    if (!settings.accounts?.sota?.idToken) return false
+    const hasHunted = qsos.filter(q => !q.deleted && findRef(q, Info.huntingType)).length > 0
+    const isActivation = findRef(operation, Info.activationType)
+    return hasHunted || isActivation
+  },
+  sendOutgoingQSLs: async ({ operation, qsos, settings, dispatch }) => {
+    const qsl = operation?.qsl?.[Info.key]
+    const operationRef = findRef(operation, Info.activationType)
+
+    const uploadQSOs = []
+    const chaseQSOs = []
+    qsos.filter(q => !q.deleted).forEach(qso => {
+      const huntRef = findRef(qso.refs, Info.huntingType)
+      if (operationRef) {
+        uploadQSOs.push({
+          date: fmtSOTADate(new Date(qso.startAtMillis)),
+          time: fmtSotaTime(new Date(qso.startAtMillis)),
+          band: sotaBands[qso.band],
+          mode: getSOTAMode(qso.mode),
+          s2sSummitCode: huntRef?.ref,
+          callsign: qso.their?.call,
+          comments: qso.notes || '',
+          location: qso.their?.grid
+        })
+      }
+      if (huntRef) {
+        chaseQSOs.push({
+          date: fmtSOTADate(new Date(qso.startAtMillis)),
+          timeStr: fmtSotaTime(new Date(qso.startAtMillis)),
+          band: sotaBands[qso.band],
+          mode: getSOTAMode(qso.mode),
+          ownCallsign: qso.our?.call,
+          otherCallsign: qso.their?.call,
+          s2sSummitCode: huntRef.ref,
+          summitCode: operationRef?.ref,
+          notes: qso.notes || '',
+          location: qso.our?.grid || operation?.grid,
+        })
+      }
+    })
+
+    let upload
+    if (operationRef) {
+      upload = {
+        activations: [{
+          date: fmtSOTADate(new Date(operation.startAtMillisMin)),
+          summit: operationRef.ref,
+          ownCallsign: operation.stationCall || settings.operatorCall,
+          qsos: uploadQSOs
+        }],
+        s2s: chaseQSOs,
+        chases: []
+      }
+    } else {
+      upload = {
+        activations: [],
+        s2s: [],
+        chases: chaseQSOs
+      }
+    }
+
+    if (qsl?.uploadID) {
+      upload.id = qsl.uploadID
+    }
+
+    const apiPromise = await dispatch(apiSOTA.endpoints.logUpload.initiate(upload, { forceRefetch: true }))
+    await Promise.all(dispatch(apiSOTA.util.getRunningQueriesThunk()))
+    const apiResults = await dispatch((_dispatch, getState) => apiSOTA.endpoints.logUpload.select(upload)(getState()))
+    apiPromise.unsubscribe && apiPromise.unsubscribe()
+
+    if (!apiResults?.error) {
+      dispatch(setOperationData({
+        uuid: operation.uuid,
+        qsl: { ...operation?.qsl, [Info.key]: {
+          error: null,
+          lastUpdated: Date.now(),
+          ref: operationRef,
+          qsosHash: qsos.filter(q => !q.deleted).reduce((hash, q) => hashCode(sotaQsoDataStr(q, operation), hash), 0),
+          uploadID: apiResults?.data?.id
+        }},
+      }))
+    } else {
+      console.log('Error uploading SOTA QSLs:', apiResults.error)
+      if (apiResults.error.data?.message === "No upload found") {
+        // Must have been deleted on SOTA data
+        dispatch(setOperationData({
+          uuid: operation.uuid,
+          qsl: { ...operation?.qsl, [Info.key]: {
+            error: apiResults.error.data?.message || 'Unknown error',
+          }},
+        }))
+      } else {
+        dispatch(setOperationData({
+          uuid: operation.uuid,
+          qsl: { ...operation?.qsl, [Info.key]: {
+            ...operation?.qsl?.[Info.key],
+            error: apiResults.error.data?.message || 'Unknown error',
+          }},
+        }))
+      }
+    }
+  },
+  qslStatusForOperation: ({ operation, qsos }) => {
+    const error = operation?.qsl?.[Info.key]?.error
+    if (!operation?.qsl?.[Info.key]?.uploadID) return { status: 'neverSent', error }
+
+    // Activation references changed?
+    const qslRef = operation.qsl?.[Info.key]?.ref || []
+    const newRef = findRef(operation, Info.activationType)
+    if (qslRef?.ref !== newRef?.ref) return { status: 'needsUpdate', error }
+
+    // QSO modified in way that concerns service?
+    const qslHash = operation.qsl?.[Info.key]?.qsosHash
+    const newHash = qsos.filter(q => !q.deleted).reduce((hash, q) => hashCode(sotaQsoDataStr(q, operation), hash), 0)
+    if (qslHash !== newHash) return { status: 'needsUpdate', error }
+
+    return { status: 'upToDate', error }
   }
 }
 
@@ -406,4 +550,35 @@ const ReferenceHandler = {
 
     return score
   }
+}
+
+const validModes = ['AM', 'CW', 'DATA', 'DV', 'FM', 'SSB']
+
+function getSOTAMode(mode) {
+  if (ADIF_MODE_FOR_SUBMODE[mode]) mode = ADIF_MODE_FOR_SUBMODE[mode]
+  if (!validModes.includes(mode)) {
+    if (mode === 'DIGITALVOICE') {
+      mode = 'DV'
+    } else if (mode){
+      mode = 'DATA' // Reasonable guess
+    }
+  }
+  return mode
+}
+
+const sotaBands = {
+  '160m': '1.8MHz',
+  '80m': '3.5MHz',
+  '60m': '5MHz',
+  '40m': '7MHz',
+  '30m': '10MHz',
+  '20m': '14MHz',
+  '17m': '18MHz',
+  '15m': '21MHz',
+  '12m': '24MHz',
+  '10m': '28MHz',
+  '6m': '50MHz',
+  '2m': '144MHz',
+  '70cm': '432MHz',
+  '23cm': '1240MHz'
 }

--- a/src/extensions/activities/wwbota/WWBOTAAccount.jsx
+++ b/src/extensions/activities/wwbota/WWBOTAAccount.jsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright ©️ 2024-2025 Sebastian Delmont <sd@ham2k.com>
+ * Copyright ©️ 2024-2026 Steven Hiscocks <steven@hiscocks.me.uk>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react'
+import { View } from 'react-native'
+import { useDispatch } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+
+import { setAccountInfo } from '../../../store/settings'
+import { apiWWBOTA } from '../../../store/apis/apiWWBOTA'
+import { H2kButton, H2kDialog, H2kDialogActions, H2kDialogContent, H2kDialogTitle, H2kListItem, H2kMarkdown, H2kText, H2kTextInput } from '../../../ui'
+
+export function WWBOTAAccountSetting ({ settings, styles }) {
+  const { t } = useTranslation()
+
+  const [currentDialog, setCurrentDialog] = useState()
+  return (
+    <>
+      <H2kListItem
+        title={t('extensions.wwbota.account.title', 'WWBOTA (for log upload)')}
+        description={settings?.accounts?.wwbota?.login ? t('extensions.wwbota.account.description', 'Login: {{login}}', { login: settings.accounts.wwbota.login }) : t('extensions.wwbota.account.noAccount', 'No account')}
+        leftIcon={'web'}
+        onPress={() => setCurrentDialog('accountsWWBOTA')}
+      />
+      {currentDialog === 'accountsWWBOTA' && (
+        <AccountsWWBOTADialog
+          settings={settings}
+          styles={styles}
+          visible={true}
+          onDialogDone={() => setCurrentDialog('')}
+        />
+      )}
+    </>
+  )
+}
+
+function AccountsWWBOTADialog ({ visible, settings, styles, onDialogDone }) {
+  const { t } = useTranslation()
+
+  const dispatch = useDispatch()
+
+  const [dialogVisible, setDialogVisible] = useState(false)
+
+  const [originalValues] = useState({
+    login: settings?.accounts?.wwbota?.login || '',
+    password: settings?.accounts?.wwbota?.password || '',
+    token: settings?.accounts?.wwbota?.token
+  })
+
+  const [login, setLogin] = useState('')
+  const [password, setPassword] = useState('')
+  const [testResult, setTestResult] = useState(null)
+
+  useEffect(() => {
+    setDialogVisible(visible)
+  }, [visible])
+
+  useEffect(() => {
+    setLogin(settings?.accounts?.wwbota?.login || '')
+    setPassword(settings?.accounts?.wwbota?.password || '')
+  }, [settings])
+
+  const onChangeLogin = useCallback((text) => {
+    setLogin(text)
+    setTestResult(null)
+  }, [setLogin])
+
+  const onChangePassword = useCallback((text) => {
+    setPassword(text)
+    setTestResult(null)
+  }, [setPassword])
+
+  const handleTest = useCallback(async () => {
+    await dispatch(setAccountInfo({ wwbota: { login, password, token: undefined } }))
+
+    const wwbotaPromise = await dispatch(apiWWBOTA.endpoints.logUpload.initiate([], { forceRefetch: true }))
+    await Promise.all(dispatch(apiWWBOTA.util.getRunningQueriesThunk()))
+    const apiResults = await dispatch((_dispatch, getState) => apiWWBOTA.endpoints.logUpload.select([])(getState()))
+    wwbotaPromise.unsubscribe && wwbotaPromise.unsubscribe()
+
+    if (apiResults?.error) {
+      setTestResult(`‼️ ${t('extensions.wwbota.account.invalidCredentials', 'Invalid credentials, please try again')}`)
+    } else {
+      setTestResult(`✅ ${t('extensions.wwbota.account.validCredentials', 'Credentials are valid!')}`)
+    }
+  }, [dispatch, login, password, t])
+
+  const handleAccept = useCallback(() => {
+    dispatch(setAccountInfo({ wwbota: { login, password, token: undefined } }))
+    setDialogVisible(false)
+    onDialogDone && onDialogDone()
+  }, [login, password, dispatch, onDialogDone])
+
+  const handleCancel = useCallback(() => {
+    dispatch(setAccountInfo({ wwbota: originalValues }))
+    setLogin(originalValues.login || '')
+    setPassword(originalValues.password || '')
+    setDialogVisible(false)
+    onDialogDone && onDialogDone()
+  }, [originalValues, dispatch, onDialogDone])
+
+  return (
+    <H2kDialog visible={dialogVisible} onDismiss={handleCancel}>
+      <H2kDialogTitle style={{ textAlign: 'center' }}>{t('extensions.wwbota.account.dialogTitle', 'WWBOTA (log upload)')}</H2kDialogTitle>
+      <H2kDialogContent>
+        <H2kText variant="bodyMedium">{t('extensions.wwbota.account.pleaseEnterDetails', 'Please enter the details for your WWBOTA account:')}</H2kText>
+        <H2kTextInput
+          style={[styles.input, { marginTop: styles.oneSpace }]}
+          value={login}
+          label={t('extensions.wwbota.account.usernameLabel', 'Username')}
+          placeholder={t('extensions.wwbota.account.usernamePlaceholder', 'your account username')}
+          onChangeText={onChangeLogin}
+        />
+        <H2kTextInput
+          style={[styles.input, { marginTop: styles.oneSpace }]}
+          value={password}
+          label={t('extensions.wwbota.account.passwordLabel', 'Password')}
+          autoComplete="current-password"
+          keyboardType="default"
+          textContentType="password"
+          secureTextEntry={true}
+          autoCapitalize={'none'}
+          placeholder={t('extensions.wwbota.account.passwordPlaceholder', 'your password')}
+          onChangeText={onChangePassword}
+        />
+        <View style={{ marginTop: styles.oneSpace, flexDirection: 'row' }}>
+          {!testResult && <H2kButton onPress={handleTest}>{t('extensions.wwbota.account.checkCredentials', 'Check Credentials')}</H2kButton>}
+          {testResult && <H2kMarkdown style={{ flex: 1, marginTop: styles.oneSpace * 0.6 }}>{testResult}</H2kMarkdown>}
+        </View>
+      </H2kDialogContent>
+      <H2kDialogActions>
+        <H2kButton onPress={handleCancel}>{t('general.buttons.cancel', 'Cancel')}</H2kButton>
+        <H2kButton onPress={handleAccept}>{t('general.buttons.ok', 'Ok')}</H2kButton>
+      </H2kDialogActions>
+    </H2kDialog>
+  )
+}

--- a/src/extensions/activities/wwbota/WWBOTAExtension.js
+++ b/src/extensions/activities/wwbota/WWBOTAExtension.js
@@ -211,8 +211,8 @@ const QSLHook = {
     Object.keys(qslUploadIDs).forEach(qsoUUID => {
       if (!qsos.find(q => !q.deleted && q.uuid === qsoUUID)) {
         qsosToDelete.push(...(qslUploadIDs[qsoUUID].uuids || []))
+        delete qslUploadIDs[qsoUUID]
       }
-      delete qslUploadIDs[qsoUUID]
     })
 
     const apiPromises = qsosToDelete.map(id => dispatch(apiWWBOTA.endpoints.deleteQSO.initiate({ id })))

--- a/src/extensions/activities/wwbota/WWBOTAExtension.js
+++ b/src/extensions/activities/wwbota/WWBOTAExtension.js
@@ -215,10 +215,9 @@ const QSLHook = {
       delete qslUploadIDs[qsoUUID]
     })
 
-    for (const wwbotaUUID of qsosToDelete) {
-      await dispatch(apiWWBOTA.endpoints.deleteQSO.initiate({id: wwbotaUUID}))
-    }
-    await Promise.all(dispatch(apiWWBOTA.util.getRunningQueriesThunk()))
+    const apiPromises = qsosToDelete.map(id => dispatch(apiWWBOTA.endpoints.deleteQSO.initiate({ id })))
+    await Promise.all(apiPromises)
+    apiPromises.forEach(p => p.unsubscribe && p.unsubscribe())
 
     let apiResults
     if (uploadQSOs.length > 0) {

--- a/src/extensions/activities/wwbota/WWBOTAExtension.js
+++ b/src/extensions/activities/wwbota/WWBOTAExtension.js
@@ -148,7 +148,7 @@ const SpotsHook = {
 }
 
 function wwbotaQsoDataStr(qso) {
-  return [qso.key, qso.our?.sent, qso.their?.sent, qso.notes, filterRefs(qso.refs, Info.huntingType).map(r => r.ref).join('|')].join('|')
+  return [qso.key, qso.our?.sent, qso.their?.sent, qso.notes, ...filterRefs(qso.refs, Info.huntingType).map(r => r.ref).sort()].join('|')
 }
 
 const QSLHook = {

--- a/src/extensions/activities/wwbota/WWBOTAExtension.js
+++ b/src/extensions/activities/wwbota/WWBOTAExtension.js
@@ -8,6 +8,8 @@
 
 import { loadDataFile, removeDataFile } from '../../../store/dataFiles/actions/dataFileFS'
 import { filterRefs, findRef, refsToString } from '../../../tools/refTools'
+import { setOperationData } from '../../../store/operations'
+import { hashCode } from '../../../tools/hashCode'
 
 import { Info } from './WWBOTAInfo'
 import { WWBOTAActivityOptions } from './WWBOTAActivityOptions'
@@ -22,6 +24,7 @@ import { annotateFromCountryFile } from '@ham2k/lib-country-files'
 import { gridToLocation } from '@ham2k/lib-maidenhead-grid'
 import { distanceOnEarth } from '../../../tools/geoTools'
 import { WWBOTAPostOtherSpot } from './WWBOTAPostOtherSpot'
+import { WWBOTAAccountSetting } from './WWBOTAAccount'
 import GLOBAL from '../../../GLOBAL'
 
 const Extension = {
@@ -34,6 +37,14 @@ const Extension = {
     registerHook(`ref:${Info.activationType}`, { hook: ReferenceHandler })
     registerHook('ref:ukbota', { hook: ReferenceHandler }) // Legacy
     registerHook('ref:ukbotaActivation', { hook: ReferenceHandler }) // Legacy
+    registerHook('setting', {
+      hook: {
+        key: 'wwbota-account',
+        category: 'account',
+        SettingItem: WWBOTAAccountSetting
+      }
+    })
+    registerHook('qsl', { hook: QSLHook })
 
     registerWWBOTADataFile()
     await dispatch(loadDataFile('wwbota-all-bunkers', { noticesInsteadOfFetch: true }))
@@ -133,6 +144,141 @@ const SpotsHook = {
       }
     }
     return dedupedQSOs
+  }
+}
+
+function wwbotaQsoDataStr(qso) {
+  return [qso.key, qso.our?.sent, qso.their?.sent, qso.notes, filterRefs(qso.refs, Info.huntingType).map(r => r.ref).join('|')].join('|')
+}
+
+const QSLHook = {
+  ...Info,
+  serviceName: 'WWBOTA Logger',
+  canSendOutgoingQSLs: ({ operation, qsos, settings }) => {
+    if (!settings.accounts?.wwbota?.login) return false
+    const hasHunted = qsos.filter(q => !q.deleted && findRef(q, Info.huntingType)).length > 0
+    const isActivation = findRef(operation, Info.activationType)
+    return hasHunted || isActivation
+  },
+  sendOutgoingQSLs: async ({ operation, qsos, settings, dispatch }) => {
+    const qsl = operation?.qsl?.[Info.key]
+    const qslUploadIDs = {...qsl?.uploadIDs || {}}
+    const operationRefs = filterRefs(operation, Info.activationType).filter(r => r.ref)
+    // To cover case where references changed
+    const allRefsUploaded = qsl?.refs?.length === operationRefs.length && operationRefs.every(ref => qsl?.refs?.find(x => x.ref === ref.ref))
+
+    const uploadQSOs = []
+    let index = 0
+    const qsoIndexes = {}
+    const qsosToDelete = []
+    qsos.filter(q => !q.deleted).forEach(qso => {
+      if (allRefsUploaded && qslUploadIDs[qso.uuid]?.hash && qslUploadIDs[qso.uuid]?.hash === hashCode(wwbotaQsoDataStr(qso))) return // Don't re-upload QSOs we've already uploaded
+      qsosToDelete.push(...(qslUploadIDs[qso.uuid]?.uuids || [])) // If we're re-uploading, delete old ones
+      qsoIndexes[qso.uuid] = []
+      operationRefs.forEach(ref => {
+        uploadQSOs.push({
+          "activator_call": qso.our?.call,
+          "band": qso.band,
+          "hunter_call": qso.their?.call,
+          "mode": qso.mode,
+          "notes": qso.notes || null,
+          "reference": ref.ref,
+          "rst_rcvd": qso.their?.sent || null,
+          "rst_sent": qso.our?.sent || null,
+          "time": new Date(qso.startAtMillis).toISOString()
+        })
+        qsoIndexes[qso.uuid].push(index++)
+      })
+      // Hunter references and also bunker 2 bunker contacts
+      const huntRefs = filterRefs(qso.refs, Info.huntingType).filter(r => r.ref)
+      huntRefs.forEach(ref => {
+        uploadQSOs.push({
+          "activator_call": qso.their?.call,
+          "band": qso.band,
+          "hunter_call": qso.our?.call,
+          "mode": qso.mode,
+          "notes": qso.notes || null,
+          "reference": ref.ref,
+          "rst_rcvd": qso.their?.sent || null,
+          "rst_sent": qso.our?.sent || null,
+          "time": new Date(qso.startAtMillis).toISOString()
+        })
+        qsoIndexes[qso.uuid].push(index++)
+      })
+    })
+
+    // Find any previously uploaded QSOs that are no longer in the log and delete them
+    Object.keys(qslUploadIDs).forEach(qsoUUID => {
+      if (!qsos.find(q => !q.deleted && q.uuid === qsoUUID)) {
+        qsosToDelete.push(...(qslUploadIDs[qsoUUID].uuids || []))
+      }
+      delete qslUploadIDs[qsoUUID]
+    })
+
+    for (const wwbotaUUID of qsosToDelete) {
+      await dispatch(apiWWBOTA.endpoints.deleteQSO.initiate({id: wwbotaUUID}))
+    }
+    await Promise.all(dispatch(apiWWBOTA.util.getRunningQueriesThunk()))
+
+    let apiResults
+    if (uploadQSOs.length > 0) {
+      const apiPromise = await dispatch(apiWWBOTA.endpoints.logUpload.initiate(uploadQSOs, { forceRefetch: true }))
+      await Promise.all(dispatch(apiWWBOTA.util.getRunningQueriesThunk()))
+      apiResults = await dispatch((_dispatch, getState) => apiWWBOTA.endpoints.logUpload.select(uploadQSOs)(getState()))
+      apiPromise.unsubscribe && apiPromise.unsubscribe()
+    }
+
+    if (!apiResults?.error) {
+      let qsosHash = 0
+      qsos.filter(q => !q.deleted).forEach(qso => {
+        const qsoKey = wwbotaQsoDataStr(qso)
+        qsosHash = hashCode(qsoKey, qsosHash)
+        if (qsoIndexes[qso.uuid]) {  // Was added or updated
+          qslUploadIDs[qso.uuid] = {
+            uuids: qsoIndexes[qso.uuid]?.map(index => apiResults?.data?.[index]).filter(x => x) || [],
+            hash: hashCode(qsoKey)
+          }
+        }
+      })
+      dispatch(setOperationData({
+        uuid: operation.uuid,
+        qsl: { ...operation?.qsl, [Info.key]: {
+          lastUpdated: Date.now(),
+          refs: operationRefs,
+          qsosHash,
+          uploadIDs: qslUploadIDs
+        }}
+      }))
+    } else {
+      console.log('Error uploading QSOs to WWBOTA', apiResults.error)
+      dispatch(setOperationData({
+        uuid: operation.uuid,
+        qsl: { ...operation?.qsl, [Info.key]: {
+          ...operation?.qsl?.[Info.key],
+          error: apiResults.error?.data?.detail?.[0]?.msg || apiResults?.error?.data?.detail || apiResults?.error?.data?.message || 'Unknown error'
+        }}
+      }))
+    }
+  },
+  qslStatusForOperation: ({ operation, qsos }) => {
+    error = operation?.qsl?.[Info.key]?.error
+    if (!operation?.qsl?.[Info.key]) return { status: 'neverSent', error }
+
+    // Activation references changed?
+    const qslRefs = operation.qsl?.[Info.key]?.refs || []
+    const newRefs = filterRefs(operation, Info.activationType)
+    if (newRefs.length !== qslRefs.length || !newRefs.every(ref => qslRefs.find(x => x.ref === ref.ref))) {
+      return { status: 'needsUpdate', error }
+    }
+
+    // QSO modified in way that concerns service?
+    const qslHash = operation.qsl?.[Info.key]?.qsosHash
+    const newHash = qsos.filter(q => !q.deleted).reduce((hash, q) => hashCode(wwbotaQsoDataStr(q), hash), 0)
+    if (qslHash !== newHash) {
+      return { status:'needsUpdate', error }
+    }
+
+    return { status: 'upToDate', error }
   }
 }
 

--- a/src/extensions/registry.js
+++ b/src/extensions/registry.js
@@ -36,7 +36,8 @@ const Hooks = {
   export: [],
   account: [],
   opSetting: [],
-  confirmation: []
+  confirmation: [],
+  qsl: []
 }
 
 const VALID_HOOK_REGEX = /^(ref:\w+)/

--- a/src/i18n/resources/en/extensions.json
+++ b/src/i18n/resources/en/extensions.json
@@ -771,6 +771,20 @@
       "name": "WWBOTA: World Wide Bunker Awards",
       "shortName": "WWBOTA",
       "exportName": "WWBOTA Activation",
+      "account": {
+        "title": "WWBOTA (log upload)",
+        "dialogTitle": "WWBOTA Account",
+        "description": "Login: {{login}}",
+        "noAccount": "No account",
+        "pleaseEnterDetails": "Please enter the details for your WWBOTA account:",
+        "usernameLabel": "Username",
+        "usernamePlaceholder": "your account username",
+        "passwordLabel": "Password",
+        "passwordPlaceholder": "your password",
+        "checkCredentials": "Check credentials",
+        "invalidCredentials": "Invalid credentials, please try again",
+        "validCredentials": "Credentials are valid!"
+      },
       "activityOptions": {
         "title_zero": "No bunkers selected for activation",
         "title_one": "Activating 1 bunker",

--- a/src/i18n/resources/en/polo.json
+++ b/src/i18n/resources/en/polo.json
@@ -88,7 +88,7 @@
       "exportSelectedFiles_one": "Export 1 selected file",
       "exportSelectedFiles_other": "Export {{count}} selected files",
       "exportAllFiles": "Export all files",
-      "exportQSOs": "Export QSOs",
+      "exportQSOs": "Export to Files",
       "pendingToDoItems_zero": "No pending to-do items",
       "pendingToDoItems_one": "1 pending to-do item",
       "pendingToDoItems_other": "{{count}} pending to-do items",
@@ -108,6 +108,18 @@
       "deleteOperationDialog": {
         "title": "Delete operation?",
         "description": "Are you sure you want to delete this operation?"
+      },
+      "uploadToServices": "Upload to Services",
+      "selectFromTheQSLOptionsBelow": "Select from services needing update below",
+      "allQSLOptionsUpToDate": "All services up to date",
+      "updateSingeQSLOption": "Upload to one service needing update",
+      "updateAllQSLOptions": "Upload to all {{count}} services",
+      "updateSelectedQSLOptions": "Upload to {{count}} services needing update",
+      "qslStatus": {
+        "neverSent": "Never sent",
+        "needsUpdate": "Needs update",
+        "upToDate": "Up to date",
+        "unknown": "Unknown status"
       }
     },
     "callInfo": {

--- a/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
@@ -29,6 +29,7 @@ import { H2kListItem, H2kListSection } from '../../../ui'
 import ScreenContainer from '../../components/ScreenContainer'
 import { ExportWavelogDialog } from './components/ExportWavelogDialog'
 import { buildTitleForOperation } from '../OperationScreen'
+import { findHooks } from '../../../extensions/registry'
 
 export default function OperationDataScreen (props) {
   const { t } = useTranslation()
@@ -140,6 +141,23 @@ export default function OperationDataScreen (props) {
     })
   }, [dispatch, operation])
 
+  const qslOptions = useMemo(() => {
+    const hooks = findHooks('qsl').filter(hook => hook.canSendOutgoingQSLs?.({ operation, qsos, settings }))
+    return hooks.map(hook => ({
+      key: hook.key,
+      icon: hook.icon,
+      label: hook.serviceName,
+      handler: hook,
+      ...hook?.qslStatusForOperation?.({ operation, qsos }) || { status: 'unknownStatus', error: 'Unknown error' }
+    }))
+  }, [operation, qsos, settings])
+
+  const handleQSLService = useCallback(({ options }) => {
+    options.forEach((option) => {
+      option.handler.sendOutgoingQSLs({ operation, qsos, settings, dispatch })
+    })
+  }, [operation, qsos, settings, dispatch])
+
   const handleImportADIF = useCallback(() => {
     pick({ mode: 'import' }).then(async (files) => {
       const [localCopy] = await keepLocalCopy({
@@ -178,6 +196,17 @@ export default function OperationDataScreen (props) {
     return t('screens.operationData.exportSelectedFiles', 'Export {{count}} selected files', { count: selectedExportOptions.length })
   }, [exportOptions.length, selectedExportOptions.length, t])
 
+  const selectedQSLOptions = useMemo(() => qslOptions.filter(option => (settings.qslServices?.[option.key] ?? option.selectedByDefault) !== false), [qslOptions, settings.qslServices])
+
+  const qslLabel = useMemo(() => {
+    const selectedNeedingUpdate = selectedQSLOptions.filter(option => option.status !== 'upToDate')
+    if (selectedNeedingUpdate.length === 0 && selectedQSLOptions.length > 0) return t('screens.operationData.selectFromTheQSLOptionsBelow', 'Select from services needing update below')
+    if (selectedNeedingUpdate.length === 0 && selectedQSLOptions.length === qslOptions.length) return t('screens.operationData.allQSLOptionsUpToDate', 'All services up to date')
+    if (selectedNeedingUpdate.length === 1) return t('screens.operationData.updateSingeQSLOption', 'Upload to one service needing update')
+    if (selectedNeedingUpdate.length === qslOptions.length) return t('screens.operationData.updateAllQSLOptions', 'Upload to all {{count}} services', { count: selectedNeedingUpdate.length })
+    return t('screens.operationData.updateSelectedQSLOptions', 'Upload to {{count}} selected services needing update', { count: selectedNeedingUpdate.length })
+  }, [qslOptions.length, selectedQSLOptions, t])
+
   const handleNavigateToLoggingTab = useCallback(() => {
     // Passing `selectedUUID` in `params` so that it makes it to the `OpLog` tab if it is present
     // but also passing it directly so that it makes it to the main screen in split view.
@@ -193,7 +222,7 @@ export default function OperationDataScreen (props) {
     <ScreenContainer>
       <SafeAreaView edges={['left', 'right', 'bottom']} style={{ flex: 1 }}>
         <ScrollView style={{ flex: 1 }}>
-          <H2kListSection title={t('screens.operationData.exportQSOs', 'Export QSOs')}>
+          <H2kListSection title={t('screens.operationData.exportQSOs', 'Export to Files')}>
 
             {pendingTodos.length > 0 && (
               <H2kListItem
@@ -235,6 +264,43 @@ export default function OperationDataScreen (props) {
               </View>
             ))}
           </H2kListSection>
+
+          { qslOptions.length > 0 && (
+            <H2kListSection title={t('screens.operationData.uploadToServices', 'Upload to Services')}>
+              <H2kListItem
+                title={qslLabel}
+                leftIcon="cloud-upload"
+                onPress={() => readyToExport && handleQSLService({ options: selectedQSLOptions.filter(option => option.status !== 'upToDate') })}
+                style={{ opacity: readyToExport ? 1 : 0.5 }}
+                disabled={!readyToExport}
+              />
+              {qslOptions.map((option) => (
+                <View key={option.key} style={{ flexDirection: 'row', width: '100%', marginLeft: styles.oneSpace * 1, alignItems: 'flex-start' }}>
+                  <View style={{ marginTop: styles.oneSpace * 1 }}>
+                    <Checkbox
+                      status={(settings.qslServices?.[option.key] ?? option.selectedByDefault) !== false ? 'checked' : 'unchecked'}
+                      onPress={() => dispatch(setSettings({ qslServices: { ...settings.qslServices, [option.key]: !((settings.qslServices?.[option.key] ?? option.selectedByDefault) !== false) } }))}
+                    />
+                  </View>
+                  <H2kListItem
+                    key={option.key}
+                    title={option.label}
+                    description={option.error || t(`screens.operationData.qslStatus.${option.status ?? 'unknown'}`, option.status === 'upToDate' ? 'Up to date' : option.status === 'needsUpdate' ? 'Needs update' : 'Never sent')}
+                    leftIcon={option.icon ?? option.handler.icon ?? 'file-outline'}
+                    leftIconColor={option.devMode ? styles.colors.devMode : styles.colors.onBackground}
+                    rightIcon={option.error ? 'alert-circle' : option.status === 'upToDate' ? 'check-circle' : option.status === 'neverSent' ? 'cloud-upload' : 'cloud-upload-outline'}
+                    rightIconColor={option.error ? styles.colors.error : option.status === 'upToDate' ? styles.colors.important : option.status === 'needsUpdate' ? styles.colors.secondary : undefined}
+                    onPressRight={() => readyToExport && handleQSLService({ options: [option] })}
+                    onPress={() => readyToExport && handleQSLService({ options: [option] })}
+                    descriptionStyle={option.devMode ? { color: styles.colors.devMode } : {}}
+                    titleStyle={option.devMode ? { color: styles.colors.devMode } : {}}
+                    style={{ opacity: readyToExport ? 1 : 0.5, flex: 1 }}
+                    disabled={!readyToExport}
+                  />
+                </View>
+              ))}
+            </H2kListSection>
+          )}
 
           <H2kListSection title={t('screens.operationData.importQSOs', 'Import QSOs')}>
             <H2kListItem

--- a/src/store/apis/apiSOTA/apiSOTA.js
+++ b/src/store/apis/apiSOTA/apiSOTA.js
@@ -132,6 +132,13 @@ export const apiSOTA = createApi({
         url: `api-db2.sota.org.uk/api/spots/${limit}/${band ?? 'all'}/${mode ?? 'all'}/`
       }),
       keepUnusedDataFor: 15 * 60 // 15 minutes
+    }),
+    logUpload: builder.query({
+      query: (body) => ({
+        url: 'api-db2.sota.org.uk/uploads',
+        method: 'POST',
+        body
+      })
     })
   })
 })

--- a/src/store/apis/apiWWBOTA/apiWWBOTA.js
+++ b/src/store/apis/apiWWBOTA/apiWWBOTA.js
@@ -1,28 +1,78 @@
 /*
  * Copyright ©️ 2024 Sebastian Delmont <sd@ham2k.com>
- * Copyright ©️ 2024 Steven Hiscocks <steven@hiscocks.me.uk>
+ * Copyright ©️ 2024-2026 Steven Hiscocks <steven@hiscocks.me.uk>
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { setAccountInfo } from '../../settings'
 
 import packageJson from '../../../../package.json'
 
 const API_TIMEOUT = 3000 // 3 seconds
+const TOKEN_TIMEOUT = 10000
+
+DEBUG = false
+
+const tokenQuery = fetchBaseQuery({
+  baseUrl: 'https://wwbota.net/wp-json/wwbota/v1/',
+  timeout: TOKEN_TIMEOUT,
+  prepareHeaders: (headers) => {
+    headers.set('Accept', 'application/json')
+    headers.set('Content-type', 'application/json')
+    headers.set('User-Agent', `ham2k-polo-${packageJson.version}`)
+  },
+})
+
+const baseQueryWithSettings = fetchBaseQuery({
+  baseUrl: 'https://api.wwbota.org/',
+  timeout: API_TIMEOUT,
+  prepareHeaders: (headers, { getState, endpoint }) => {
+    headers.set('Accept', 'application/json')
+    headers.set('Content-type', 'application/json')
+    headers.set('User-Agent', `ham2k-polo-${packageJson.version}`)
+    if (!(endpoint === 'spots' || endpoint === 'spot' || endpoint === 'editSpot')) {
+      headers.set('Authorization', `Bearer ${getState().settings?.accounts?.wwbota?.token}`)
+    }
+  },
+})
+
+const baseQueryWithReauth = async (args, api, extraOptions) => {
+  if (DEBUG) console.log('baseQueryWithReauth first call', { args })
+  let result = await baseQueryWithSettings(args, api, extraOptions)
+
+  if (result.error && result.error.status === 401) {
+    // try to get a new session key
+    const { login, password } = api.getState().settings?.accounts?.wwbota ?? {}
+    if (DEBUG) console.log('baseQueryWithReauth second call')
+    result = await tokenQuery({
+      method: 'POST',
+      url: 'token',
+      body: { username: login, password },
+    }, api, extraOptions)
+
+    if (result.error) return result
+
+    const newToken = result.data?.token
+    if (newToken) {
+      if (DEBUG) console.log('New Token', newToken)
+      await api.dispatch(setAccountInfo({ wwbota: { ...api.getState().settings?.accounts?.wwbota, token: newToken } }))
+
+      if (DEBUG) console.log('baseQueryWithReauth third call')
+      result = await baseQueryWithSettings(args, api, extraOptions)
+    } else {
+      await api.dispatch(setAccountInfo({ wwbota: { ...api.getState().settings?.accounts?.wwbota, token: undefined } }))
+      return { error: 'Unexpected error logging into WWBOTA', result }
+    }
+  }
+  return result
+}
 
 export const apiWWBOTA = createApi({
   reducerPath: 'apiWWBOTA',
-  baseQuery: fetchBaseQuery({
-    baseUrl: 'https://api.wwbota.org/',
-    timeout: API_TIMEOUT,
-    prepareHeaders: (headers, { getState, endpoint }) => {
-      headers.set('Accept', 'application/json')
-      headers.set('Content-type', 'application/json')
-      headers.set('User-Agent', `ham2k-polo-${packageJson.version}`)
-    }
-  }),
+  baseQuery: baseQueryWithReauth,
   endpoints: builder => ({
     spots: builder.query({
       query: () => 'spots/',
@@ -40,6 +90,19 @@ export const apiWWBOTA = createApi({
         url: `spots/${id}`,
         method: 'PUT',
         body
+      })
+    }),
+    logUpload: builder.query({
+      query: (body) => ({
+        url: 'logs/',
+        method: 'POST',
+        body
+      })
+    }),
+    deleteQSO: builder.query({
+      query: ({id}) => ({
+        url: `logs/${id}`,
+        method: 'DELETE'
       })
     })
   })

--- a/src/tools/hashCode.js
+++ b/src/tools/hashCode.js
@@ -8,9 +8,8 @@
 /* eslint-disable no-bitwise */
 
 // From https://stackoverflow.com/questions/6122571/simple-non-secure-hash-function-for-javascript
-export function hashCode (str) {
+export function hashCode (str, hash = 0) {
   str = str ?? ''
-  let hash = 0
   for (let i = 0, len = str.length; i < len; i++) {
     const chr = str.charCodeAt(i)
     hash = (hash << 5) - hash + chr

--- a/src/ui/react-native/H2kListItem.jsx
+++ b/src/ui/react-native/H2kListItem.jsx
@@ -20,7 +20,7 @@ export function H2kListItem ({
   accessibilityLabel, accesibilityHint, accessibilityRole,
   accessibilityTitle, accessibilityDescription,
   leftIcon, leftIconColor, left,
-  rightIcon, right, onPressRight,
+  rightIcon, rightIconColor, right, onPressRight,
   rightSwitchValue, rightSwitchOnValueChange,
   ...moreProps
 }) {
@@ -93,14 +93,13 @@ export function H2kListItem ({
       return () => <Switch value={rightSwitchValue} onValueChange={rightSwitchOnValueChange} />
     } else if (rightIcon) {
       if (onPressRight) {
-        return () => <H2kIconButton icon={rightIcon} size={styles.oneSpace * 3} style={{ marginRight: styles.oneSpace * 2 }} onPress={onPressRight} />
+        return () => <H2kIconButton icon={rightIcon} iconColor={rightIconColor} size={styles.oneSpace * 3} style={{ marginRight: styles.oneSpace * 2 }} onPress={onPressRight} />
       } else {
-        return () => <View style={{ marginRight: styles.oneSpace * 2 }}><H2kIcon icon={rightIcon} /></View>
+        return () => <View style={{ marginRight: styles.oneSpace * 2 }}><H2kIcon icon={rightIcon} color={rightIconColor} /></View>
       }
     }
     return null
-  }, [right, rightSwitchValue, rightIcon, rightSwitchOnValueChange, onPressRight, styles.oneSpace])
-
+  }, [right, rightSwitchValue, rightIcon, rightSwitchOnValueChange, onPressRight, styles.oneSpace, rightIconColor])
   const actualAccessibilityLabel = useMemo(() => {
     if (accessibilityLabel) {
       return accessibilityLabel


### PR DESCRIPTION
Adds a new feature to allow logs to be uploaded to online services, with initial version supporting SOTA and WWBOTA.

Screenshot shows list of services, one up to date, and one requiring modified QSOs to be sent. The code validates if any fields have changed relevant to avoid updates where not needed e.g. P2P added to QSO wouldn't need to update POTA or WWBOTA.

<img height="350" alt="Screenshot From 2026-02-08 14-07-42" src="https://github.com/user-attachments/assets/fecb1e82-3803-4ca4-974a-6361e6333565" />


If any errors occur during upload, the server response error messages are displayed instead of the upload status.
<img height="360" alt="Screenshot From 2026-02-08 14-14-52" src="https://github.com/user-attachments/assets/fe0a715b-a67a-4517-96d1-8b23948d2f50" />
