### PR TITLE
Add controls for rig and antenna

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,8 @@ npm start -- --reset-cache
 
 - Reference: https://www.iosdev.recipes/simctl/
 - `xcrun simctl listapps booted` to list installed simulator apps.
-- `open \`xcrun simctl get_app_container booted com.ham2k.polo data\`/Documents` to open PoLo's Documents folder.
-- `open \`xcrun simctl get_app_container booted com.apple.DocumentsApp groups |grep FileProvider.LocalStorage|sed "s/group.com.apple.FileProvider.LocalStorage//g"\`/File\ Provider\ Storage` to open simulator Files local storage.
+- ``open `xcrun simctl get_app_container booted com.ham2k.polo data`/Documents`` to open PoLo's Documents folder.
+- ``open `xcrun simctl get_app_container booted com.apple.DocumentsApp groups |grep FileProvider.LocalStorage|sed "s/group.com.apple.FileProvider.LocalStorage//g"`/File\ Provider\ Storage`` to open simulator Files local storage.
 
 ## Resources
 

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel.jsx
@@ -249,6 +249,12 @@ export default function LoggingPanel ({
     } else if (fieldId === 'power') {
       updateQSO({ power: value })
       if (qso?._isNew) dispatch(setVFO({ power: value }))
+    } else if (fieldId === 'rig') {
+      updateQSO({ rig: value })
+      if (qso?._isNew) dispatch(setVFO({ rig: value }))
+    } else if (fieldId === 'antenna') {
+      updateQSO({ antenna: value })
+      if (qso?._isNew) dispatch(setVFO({ antenna: value }))
     } else if (fieldId === 'eventNote') {
       updateQSO({ event: { note: value } })
     } else if (fieldId === 'eventData') {
@@ -773,6 +779,8 @@ function prepareNewQSO (operation, qsos, vfo, settings) {
     freq: vfo.freq,
     mode: vfo.mode,
     power: vfo.power,
+    rig: vfo.rig,
+    antenna: vfo.antenna,
     _isNew: true
   }
   if (operation.local?._nextManualTime) {

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel.jsx
@@ -11,6 +11,8 @@ import { timeControl } from './SecondaryExchangePanel/TimeControl'
 import { radioControl } from './SecondaryExchangePanel/RadioControl'
 import { notesControl } from './SecondaryExchangePanel/NotesControl'
 import { powerControl } from './SecondaryExchangePanel/TxPowerControl'
+import { rigControl } from './SecondaryExchangePanel/RigControl'
+import { antennaControl } from './SecondaryExchangePanel/AntennaControl'
 import { SecondaryControlManagementSubPanel } from './SecondaryExchangePanel/SecondaryControlManagementSubPanel'
 import { SecondaryControlSelectionsubPanel } from './SecondaryExchangePanel/SecondaryControlSelectionSubPanel'
 import { findHooks } from '../../../../../extensions/registry'
@@ -31,7 +33,9 @@ export const SecondaryExchangePanel = (props) => {
       radio: radioControl,
       notes: notesControl,
       edit: editQSOControl,
-      power: powerControl
+      power: powerControl,
+      rig: rigControl,
+      antenna: antennaControl
     }
 
     const activityHooks = findHooks('activity')

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel/AntennaControl.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel/AntennaControl.jsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright ©️ 2024-2026 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useEffect, useRef } from 'react'
+import { View } from 'react-native'
+import { useTranslation } from 'react-i18next'
+
+import GLOBAL from '../../../../../../GLOBAL'
+
+import { H2kTextInput } from '../../../../../../ui'
+
+const AntennaControl = ({ qso, operation, settings, disabled, icon, style, styles, themeColor, handleFieldChange, onSubmitEditing, focusedRef }) => {
+  const { t } = useTranslation()
+
+  const ref = useRef()
+  useEffect(() => { setTimeout(() => ref?.current?.focus(), 200) }, [])
+
+  return (
+    <View style={[style, { flexDirection: 'row', paddingHorizontal: 0, gap: styles.oneSpace }]}>
+      <H2kTextInput
+        innerRef={ref}
+        themeColor={themeColor}
+        style={[styles.input, { minWidth: styles.oneSpace * 10, width: '100%' }]}
+        value={qso?.antenna ?? ''}
+        disabled={disabled}
+        label={t('screens.opLoggingTab.antennaLabel', 'Antenna')}
+        placeholder=""
+        onChange={handleFieldChange}
+        onSubmitEditing={onSubmitEditing}
+        fieldId={'antenna'}
+        focusedRef={focusedRef}
+        keyboard="dumb"
+      />
+    </View>
+  )
+}
+
+export const antennaControl = {
+  key: 'antenna',
+  icon: 'antenna',
+  order: 5,
+  label: ({ qso, operation, settings }) => {
+    if (qso?.antenna) {
+      return qso.antenna
+    } else {
+      return GLOBAL?.t?.('screens.opLoggingTab.antennaLabel', 'Antenna') || 'Antenna'
+    }
+  },
+  accessibilityLabel: GLOBAL?.t?.('screens.opLoggingTab.antennaControls-a11y', 'Antenna Controls') || 'Antenna Controls',
+  InputComponent: AntennaControl,
+  inputWidthMultiplier: 30,
+  optionType: 'optional'
+}

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel/RigControl.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/SecondaryExchangePanel/RigControl.jsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright ©️ 2024-2026 Sebastian Delmont <sd@ham2k.com>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import React, { useEffect, useRef } from 'react'
+import { View } from 'react-native'
+import { useTranslation } from 'react-i18next'
+
+import GLOBAL from '../../../../../../GLOBAL'
+
+import { H2kTextInput } from '../../../../../../ui'
+
+const RigControl = ({ qso, operation, settings, disabled, icon, style, styles, themeColor, handleFieldChange, onSubmitEditing, focusedRef }) => {
+  const { t } = useTranslation()
+
+  const ref = useRef()
+  useEffect(() => { setTimeout(() => ref?.current?.focus(), 200) }, [])
+
+  return (
+    <View style={[style, { flexDirection: 'row', paddingHorizontal: 0, gap: styles.oneSpace }]}>
+      <H2kTextInput
+        innerRef={ref}
+        themeColor={themeColor}
+        style={[styles.input, { minWidth: styles.oneSpace * 10, width: '100%' }]}
+        value={qso?.rig ?? ''}
+        disabled={disabled}
+        label={t('screens.opLoggingTab.rigLabel', 'Rig')}
+        placeholder=""
+        onChange={handleFieldChange}
+        onSubmitEditing={onSubmitEditing}
+        fieldId={'rig'}
+        focusedRef={focusedRef}
+        keyboard="dumb"
+      />
+    </View>
+  )
+}
+
+export const rigControl = {
+  key: 'rig',
+  icon: 'radio',
+  order: 4,
+  label: ({ qso, operation, settings }) => {
+    if (qso?.rig) {
+      return qso.rig
+    } else {
+      return GLOBAL?.t?.('screens.opLoggingTab.rigLabel', 'Rig') || 'Rig'
+    }
+  },
+  accessibilityLabel: GLOBAL?.t?.('screens.opLoggingTab.rigControls-a11y', 'Rig Controls') || 'Rig Controls',
+  InputComponent: RigControl,
+  inputWidthMultiplier: 30,
+  optionType: 'optional'
+}

--- a/src/tools/qsonToADIF.js
+++ b/src/tools/qsonToADIF.js
@@ -198,6 +198,8 @@ function adifFieldsForOneQSO({ qso, operation, common, privateData, templates, t
     { GRIDSQUARE: privateData && (qso.their?.grid ?? qso.their?.guess?.grid) },
     { MY_GRIDSQUARE: privateData && (qso?.our?.grid ?? common.grid) },
     { MY_STATE: qso?.our?.state ?? common.state },
+    { MY_RIG: qso?.rig },
+    { MY_ANTENNA: qso?.antenna },
     { MY_CNTY: privateData && _cleanCounty(qso?.our?.county ?? common.county, qso?.our?.state ?? common.state) },
     { NAME: privateData && (qso.their?.name ?? qso.their?.guess?.name) },
     { DXCC: qso.their?.dxccCode ?? qso.their?.guess?.dxccCode },


### PR DESCRIPTION
Adds a couple of controls to specify rig and antenna used for QSO, exports them to ADIF as MY_RIG and MY_ANTENNA.

| Screenshot |
| - |
| <img width="255" height="92" alt="image" src="https://github.com/user-attachments/assets/6a29d460-b41d-467c-900b-d82df942e09c" /> |