### PR TITLE
Fix number/call styling

### DIFF
--- a/src/screens/OperationScreens/OpLoggingTab/components/QSOList.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/QSOList.jsx
@@ -362,15 +362,18 @@ function _prepareStyles (themeStyles, { componentWidth: width, safeArea, hasFreq
       },
       freqMHz: {
         ...commonStyles,
+        ...themeStyles.text.numbers,
         fontWeight: '600',
         textAlign: 'right'
       },
       freqKHz: {
         ...commonStyles,
+        ...themeStyles.text.numbers,
         textAlign: 'right'
       },
       freqHz: {
         ...commonStyles,
+        ...themeStyles.text.numbers,
         textAlign: 'right',
         fontWeight: '400',
         fontSize: normalFontSize * 0.7

--- a/src/styles/globalStyles.js
+++ b/src/styles/globalStyles.js
@@ -179,16 +179,17 @@ export const prepareGlobalStyles = ({ theme, colorScheme, width, height }) => {
       numbers: {
         fontVariant: ['tabular-nums'],
         fontFamily: 'Roboto Mono',
-        fontWeight: 'regular'
+        fontWeight: 'normal'
       },
       callsign: {
         fontVariant: ['tabular-nums'],
         fontFamily: 'Roboto Mono',
-        fontWeight: 'regular'
+        fontWeight: 'normal'
       },
       callsignBold: {
         fontVariant: ['tabular-nums'],
-        fontFamily: 'Roboto Mono Bold'
+        fontFamily: 'Roboto Mono',
+        fontWeight: 'bold'
       },
       bold: {
         fontWeight: 'bold'


### PR DESCRIPTION
Fix [inconsistent styling](https://forums.ham2k.com/t/incorrect-font-for-callsign-in-ios/317) on iOS after app resume.

| Before | After |
| - | - |
| <img width="200" height="102" alt="image" src="https://github.com/user-attachments/assets/13a31c4b-e09f-441a-87e1-1173c5639861" /> | <img width="200" height="102" alt="image" src="https://github.com/user-attachments/assets/a06afc8f-9d6f-4e3d-8606-8e3931a9bd9d" /> |