### PR TITLE
Fix issue with file export mime type

### DIFF
--- a/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
@@ -112,7 +112,7 @@ export default function OperationDataScreen (props) {
       if (exports?.length > 0) {
         const shareOptions = {
           urls: exports.map(e => e.uri),
-          mimeType: 'text/plain',
+          type: 'text/plain',
           showAppsToView: true
         }
         if (useDataURIs) {


### PR DESCRIPTION
Reports of issues with mime type making ADIF files audio files on Android.

Based on [react-native-share docs](https://react-native-share.github.io/react-native-share/docs/share-open#supported-options) the mime type should be set with `type` not `mimeType`.

Not tested yet, but will test later this evening when I can get to dev machine.

- [x] Test fix