### PR TITLE
Use call note text from highest priority source

### DIFF
--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/callNoteTools.js
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/callNoteTools.js
@@ -13,14 +13,10 @@ export const MAX_DISPLAY_EMOJIS = 4
 
 /**
  * Combines notes from multiple callsign notes files into a single display string.
- * Collects unique leading emojis from all notes and uses the text from the last note.
+ * Collects unique leading emojis from all notes and uses the text from the highest-priority note.
  *
- * The `notes` array is expected to be sorted by source priority, and for each source,
- * by note order.
- *
- * Later sources are considered more important than earlier sources,
- * but within a source, the earlier notes are considered more important than later notes.
- * (this could have been simpler, but as usual, "historical reasons" get in the way)
+ * The `notes` array is expected to be sorted by source priority (highest priority first),
+ * which is the order returned by `findAllCallNotes`. Earlier notes in the array take precedence.
  *
  * @param {Array} notes - Array of note objects with { source, call, note } properties
  * @param {Object} theirInfo - Call info with { baseCall, call } properties
@@ -35,20 +31,9 @@ export function combineCallNotes(notes, theirInfo) {
     return null
   }
 
-  // Capture the order of sources
-  const uniqueSources = new Set(matchingNotes.map(note => note.source))
-  const sourceOrder = Array.from(uniqueSources)
-    .map((source, index) => ({ source, index }))
-    .reduce((acc, r) => { acc[r.source] = r.index; return acc }, {})
-
-  // Reorder notes by source order and then reverse "within source" order
-  const sortedNotes = matchingNotes.map((note, index) => ({ note, index }))
-    .sort((a, b) => (sourceOrder[a.note.source] - sourceOrder[b.note.source]) || (b.index - a.index))
-    .map(r => r.note)
-
-  // Collect unique emojis from all notes
+  // Collect unique emojis from all notes (highest priority first)
   const emojis = []
-  for (const note of sortedNotes) {
+  for (const note of matchingNotes) {
     if (note.note) {
       const matches = note.note.match(EMOJI_REGEX)
       if (matches && matches[0] && !emojis.includes(matches[0])) {
@@ -57,24 +42,23 @@ export function combineCallNotes(notes, theirInfo) {
     }
   }
 
-  // Get the text from the last note's text, strip its leading emoji
-  const lastNote = sortedNotes[sortedNotes.length - 1]
-  let noteText = lastNote.note || ''
-  const lastNoteEmojiMatch = noteText.match(EMOJI_REGEX)
-  if (lastNoteEmojiMatch && noteText.startsWith(lastNoteEmojiMatch[0])) {
-    noteText = noteText.slice(lastNoteEmojiMatch[0].length).trimStart()
+  // Use the text from the highest-priority note (first in array), strip its leading emoji
+  const topNote = matchingNotes[0]
+  let noteText = topNote.note || ''
+  const topNoteEmojiMatch = noteText.match(EMOJI_REGEX)
+  if (topNoteEmojiMatch && noteText.startsWith(topNoteEmojiMatch[0])) {
+    noteText = noteText.slice(topNoteEmojiMatch[0].length).trimStart()
   }
 
-  // Combine emojis (capped) with the stripped note text
-  // But we reverse the order to show the most important emoji last,
-  // next to the corresponding `noteText`
-  const displayEmojis = emojis.reverse().slice(0, MAX_DISPLAY_EMOJIS)
-  const emojiStr = displayEmojis.reverse().join('')
+  // Display emojis reversed so the highest-priority emoji appears last, next to the note text.
+  // Keep only the most important emojis (first in array) when capping.
+  const cappedEmojis = emojis.slice(0, MAX_DISPLAY_EMOJIS)
   const overflowIndicator = emojis.length > MAX_DISPLAY_EMOJIS ? `+${emojis.length - MAX_DISPLAY_EMOJIS}` : ''
+  const emojiStr = [...cappedEmojis].reverse().join('')
   const combinedNote = emojiStr ? `${emojiStr}${overflowIndicator} ${noteText}` : noteText
 
   return {
     note: combinedNote,
-    emoji: displayEmojis.length > 0 ? displayEmojis[displayEmojis.length - 1] : '⭐️'
+    emoji: cappedEmojis[0] || '⭐️'
   }
 }

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/callNoteTools.spec.js
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/callNoteTools.spec.js
@@ -66,7 +66,7 @@ describe('combineCallNotes', () => {
       expect(result.emoji).toBe('🍄')
     })
 
-    it('uses text from last note, stripped of its emoji', () => {
+    it('uses text from first note, stripped of its emoji', () => {
       const notes = [
         { call: 'W1AW', note: '🍄 First note text' },
         { call: 'W1AW', note: '⚓ Last note text' }
@@ -136,22 +136,11 @@ describe('combineCallNotes', () => {
 
   describe('multiple notes from multiple sources', () => {
     const theirInfo = { baseCall: 'KI2D', call: 'KI2D' }
-    it('combines notes from multiple sources', () => {
+    it('uses text from the first (highest-priority) source', () => {
       const notes = [
         { call: 'KI2D', note: '🌄 HVCDX Member', source: 'HVCDX Members' },
         { call: 'KI2D', note: '🤩 Ham2K PoLo Creator', source: 'Ham2K Notes' },
         { call: 'KI2D', note: '☕️ Ham2K Supporter', source: 'Ham2K Notes' },
-      ]
-      const result = combineCallNotes(notes, theirInfo)
-      expect(result.note).toBe('🌄☕️🤩 Ham2K PoLo Creator')
-      expect(result.emoji).toBe('🤩')
-    })
-
-    it('combines notes from multiple sources in different order', () => {
-      const notes = [
-        { call: 'KI2D', note: '🤩 Ham2K PoLo Creator', source: 'Ham2K Notes' },
-        { call: 'KI2D', note: '☕️ Ham2K Supporter', source: 'Ham2K Notes' },
-        { call: 'KI2D', note: '🌄 HVCDX Member', source: 'HVCDX Members' },
       ]
       const result = combineCallNotes(notes, theirInfo)
       expect(result.note).toBe('☕️🤩🌄 HVCDX Member')


### PR DESCRIPTION
The call note extension has support for updating the call note source priority. When fetching the note text to display, the text from the last source was being returned (this was expected before the priority re-ordering change). To simplify things and have the text match the expectations of the prioritized list, return the note text from the first source.