### PR TITLE
Improve roving map origin markers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@ham2k/lib-geo-tools": "1.0.1",
         "@ham2k/lib-operation-data": "1.0.4",
         "@ham2k/lib-qson-adif": "1.0.2",
-        "@ham2k/lib-qson-tools": "1.2.0",
+        "@ham2k/lib-qson-tools": "1.3.1",
         "@nozbe/microfuzz": "1.0.0",
         "@op-engineering/op-sqlite": "^16.2.0",
         "@react-native-async-storage/async-storage": "3.1.1",
@@ -2370,9 +2370,9 @@
       }
     },
     "node_modules/@ham2k/lib-qson-tools": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ham2k/lib-qson-tools/-/lib-qson-tools-1.2.0.tgz",
-      "integrity": "sha512-Phfg1BsF8Bm8PmtYPZdt8qupNKc5if9cdCpnhfUp+RGkX4t23XaSPc+ZCb0Q6gTf7rIViKY3NUmC66aKkX2p0g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ham2k/lib-qson-tools/-/lib-qson-tools-1.3.1.tgz",
+      "integrity": "sha512-BcL92F6toExJ3MwnDauD/wwkODHqUNJRQ403DYhGVD/mJYAtHK77gbbCi6PS0iCsmn3zLIQl74/E9dqsohCWaA==",
       "license": "MIT"
     },
     "node_modules/@hapi/hoek": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ham2k/lib-geo-tools": "1.0.1",
     "@ham2k/lib-operation-data": "1.0.4",
     "@ham2k/lib-qson-adif": "1.0.2",
-    "@ham2k/lib-qson-tools": "1.2.0",
+    "@ham2k/lib-qson-tools": "1.3.1",
     "@nozbe/microfuzz": "1.0.0",
     "@op-engineering/op-sqlite": "16.2.0",
     "@react-native-async-storage/async-storage": "3.1.1",

--- a/src/screens/OperationBadgeScreen/OperationBadgeScreen.jsx
+++ b/src/screens/OperationBadgeScreen/OperationBadgeScreen.jsx
@@ -104,8 +104,6 @@ export default function OperationBadgeScreen ({ navigation, route }) {
   const allQsosSelector = useCallback((state) => selectQSOs(state, route.params.operation.uuid), [route.params.operation.uuid])
   const allQsos = useSelector(allQsosSelector)
 
-  const qsos = useMemo(() => allQsos.filter(qso => !qso.deleted && !qso.event), [allQsos])
-
   const qth = useMemo(() => {
     try {
       if (!operation?.grid) return {}
@@ -121,9 +119,9 @@ export default function OperationBadgeScreen ({ navigation, route }) {
   }, [operation])
 
   const opStats = useMemo(() => {
-    const activeQSOsLength = qsos.filter(qso => !qso.deleted).length
+    const activeQSOsLength = allQsos.filter(qso => !qso.deleted).length
     return `${activeQSOsLength} ${activeQSOsLength === 1 ? 'QSO' : 'QSOs'} in ${fmtTimeBetween(operation.startAtMillisMin, operation.startAtMillisMax)}`
-  }, [qsos, operation])
+  }, [allQsos, operation])
 
   const [projection, setProjection] = useState('mercator')
 
@@ -135,7 +133,7 @@ export default function OperationBadgeScreen ({ navigation, route }) {
         styles={styles}
         operation={operation}
         qth={qth}
-        qsos={qsos}
+        qsos={allQsos}
         settings={settings}
         projection={projection}
       />

--- a/src/screens/OperationScreens/OpMapTab/OpMapTab.jsx
+++ b/src/screens/OperationScreens/OpMapTab/OpMapTab.jsx
@@ -55,8 +55,6 @@ export default function OpMapTab ({ navigation, route }) {
   const allQsosSelector = useCallback((state) => selectQSOs(state, route.params.operation.uuid), [route.params.operation.uuid])
   const allQsos = useSelector(allQsosSelector)
 
-  const qsos = useMemo(() => allQsos.filter(qso => !qso.deleted && !qso.event), [allQsos])
-
   const [dismissedWarnings, setDismissedWarnings] = useState({})
 
   const warnings = useMemo(() => {
@@ -76,9 +74,9 @@ Tap here to do it.`),
       })
     }
 
-    const qsosWithNoLocation = qsos.filter(qso => !qso.their?.grid && !qso.their?.guess?.grid)
+    const qsosWithNoLocation = allQsos.filter(qso => !qso.their?.grid && !qso.their?.guess?.grid)
 
-    if (qsosWithNoLocation.length / qsos.length > 0.5 && qsos.length > 5) {
+    if (qsosWithNoLocation.length / allQsos.length > 0.5 && allQsos.length > 5) {
       _warnings.push({
         key: 'many-no-location',
         text: t('screens.opMapTab.manyNoLocation', `Many of these QSOs have no precise location.
@@ -88,7 +86,7 @@ You might need a paid QRZ.com account for location lookups.`),
       })
     }
     return _warnings
-  }, [navigation, operation.uuid, qsos, qth?.latitude, t])
+  }, [allQsos, navigation, operation.uuid, qth?.latitude, t])
 
   const [keyboardPaddingBottom, setKeyboardPaddingBottom] = useState(0)
   useEffect(() => {
@@ -129,7 +127,7 @@ You might need a paid QRZ.com account for location lookups.`),
         projection={projection}
         operation={operation}
         qth={qth}
-        qsos={qsos}
+        qsos={allQsos}
         settings={settings}
         selectedUUID={selectedUUID}
       />

--- a/src/screens/OperationScreens/OpMapTab/components/MapWithQSOs.jsx
+++ b/src/screens/OperationScreens/OpMapTab/components/MapWithQSOs.jsx
@@ -3,24 +3,52 @@
 
 import React, { useMemo } from 'react'
 
-import { distanceOnEarth, fmtDistance, locationForQSONInfo } from '@ham2k/lib-geo-tools'
+import { distanceOnEarth, fmtDistance, gridToLocation, locationForQSONInfo } from '@ham2k/lib-geo-tools'
+import { mapQSOsWithSectionContext } from '@ham2k/lib-qson-tools'
 
 import MapboxMapWithQSOs from './MapboxMapWithQSOs'
 
 export default function MapWithQSOs ({ styles, operation, qth, qsos, settings, selectedUUID, projection }) {
+  const qsosWithOriginContext = useMemo(() => {
+    const locationForGrid = (grid) => {
+      if (!grid) return qth
+      try {
+        const [latitude, longitude] = gridToLocation(grid)
+        return { latitude, longitude }
+      } catch (e) {
+        return qth
+      }
+    }
+
+    return mapQSOsWithSectionContext({
+      qsos,
+      operation,
+      map: ({ qso, sectionGrid }) => ({
+        ...qso,
+        our: {
+          ...qso.our,
+          grid: sectionGrid,
+          location: locationForGrid(sectionGrid)
+        }
+      })
+    })
+  }, [operation, qsos, qth])
+
   const mappableQSOs = useMemo(() => {
-    const activeQSOs = qsos.filter(qso => !qso.deleted && !qso.event)
+    const activeQSOs = qsosWithOriginContext.filter(qso => !qso.deleted && !qso.event)
     return activeQSOs
       .map(qso => {
         const location = locationForQSONInfo(qso?.their)
+        const ourLocation = qso?.our?.location ?? qth
+        const ourGrid = qso?.our?.grid ?? operation.grid
         const strength = strengthForQSO(qso)
-        const distance = location && qth ? distanceOnEarth(location, qth, { units: settings.distanceUnits }) : null
+        const distance = location && ourLocation ? distanceOnEarth(location, ourLocation, { units: settings.distanceUnits }) : null
         const distanceStr = distance ? fmtDistance(distance, { units: settings.distanceUnits }) : ''
-        return { qso, location, strength, distance, distanceStr }
+        return { qso, location, ourLocation, ourGrid, strength, distance, distanceStr }
       })
       .filter(({ location }) => location)
       .sort((a, b) => b.strength - a.strength) // Weakest first
-  }, [qsos, qth, settings])
+  }, [operation.grid, qsosWithOriginContext, qth, settings])
 
   const initialRegion = useMemo(() => {
     const { latitude, longitude } = qth
@@ -28,11 +56,15 @@ export default function MapWithQSOs ({ styles, operation, qth, qsos, settings, s
     let latitudeMax = latitude ?? 0
     let longitudeMin = longitude ?? 0
     let longitudeMax = longitude ?? 0
-    for (const { location } of mappableQSOs) {
+    for (const { location, ourLocation } of mappableQSOs) {
       latitudeMin = Math.min(latitudeMin, location?.latitude ?? 0)
       latitudeMax = Math.max(latitudeMax, location?.latitude ?? 0)
       longitudeMin = Math.min(longitudeMin, location?.longitude ?? 0)
       longitudeMax = Math.max(longitudeMax, location?.longitude ?? 0)
+      latitudeMin = Math.min(latitudeMin, ourLocation?.latitude ?? 0)
+      latitudeMax = Math.max(latitudeMax, ourLocation?.latitude ?? 0)
+      longitudeMin = Math.min(longitudeMin, ourLocation?.longitude ?? 0)
+      longitudeMax = Math.max(longitudeMax, ourLocation?.longitude ?? 0)
     }
     return {
       latitude: latitudeMin + (latitudeMax - latitudeMin) / 2,
@@ -46,7 +78,7 @@ export default function MapWithQSOs ({ styles, operation, qth, qsos, settings, s
     }
   }, [qth, mappableQSOs])
 
-  return <MapboxMapWithQSOs styles={styles} mappableQSOs={mappableQSOs} initialRegion={initialRegion} operation={operation} qth={qth} qsos={qsos} settings={settings} selectedUUID={selectedUUID} projection={projection} />
+  return <MapboxMapWithQSOs styles={styles} mappableQSOs={mappableQSOs} initialRegion={initialRegion} operation={operation} qth={qth} qsos={qsosWithOriginContext} settings={settings} selectedUUID={selectedUUID} projection={projection} />
 }
 
 function strengthForQSO (qso) {

--- a/src/screens/OperationScreens/OpMapTab/components/MapWithQSOs.jsx
+++ b/src/screens/OperationScreens/OpMapTab/components/MapWithQSOs.jsx
@@ -23,8 +23,9 @@ export default function MapWithQSOs ({ styles, operation, qth, qsos, settings, s
     return mapQSOsWithSectionContext({
       qsos,
       operation,
-      map: ({ qso, sectionGrid }) => ({
+      map: ({ qso, sectionGrid, sectionRefs }) => ({
         ...qso,
+        sectionRefs,
         our: {
           ...qso.our,
           grid: sectionGrid,
@@ -41,14 +42,15 @@ export default function MapWithQSOs ({ styles, operation, qth, qsos, settings, s
         const location = locationForQSONInfo(qso?.their)
         const ourLocation = qso?.our?.location ?? qth
         const ourGrid = qso?.our?.grid ?? operation.grid
+        const originRefs = qso?.sectionRefs ?? operation.refs
         const strength = strengthForQSO(qso)
         const distance = location && ourLocation ? distanceOnEarth(location, ourLocation, { units: settings.distanceUnits }) : null
         const distanceStr = distance ? fmtDistance(distance, { units: settings.distanceUnits }) : ''
-        return { qso, location, ourLocation, ourGrid, strength, distance, distanceStr }
+        return { qso, location, ourLocation, ourGrid, originRefs, strength, distance, distanceStr }
       })
       .filter(({ location }) => location)
       .sort((a, b) => b.strength - a.strength) // Weakest first
-  }, [operation.grid, qsosWithOriginContext, qth, settings])
+  }, [operation.grid, operation.refs, qsosWithOriginContext, qth, settings])
 
   const initialRegion = useMemo(() => {
     const { latitude, longitude } = qth

--- a/src/screens/OperationScreens/OpMapTab/components/MapboxMapWithQSOs.jsx
+++ b/src/screens/OperationScreens/OpMapTab/components/MapboxMapWithQSOs.jsx
@@ -3,11 +3,12 @@
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Mapbox, { StyleURL, Camera, CircleLayer, LineLayer, MapView, MarkerView, ShapeSource, Atmosphere } from '@rnmapbox/maps'
-import { Platform, View } from 'react-native'
+import { Platform, Pressable, View } from 'react-native'
 import { Text } from 'react-native-paper'
 import Config from 'react-native-config'
 
 import { fmtShortTimeZulu } from '@ham2k/lib-format-tools'
+import { buildOriginFeatureCollection, buildOriginGroups, coordsFromLatLon } from './mapOriginGroups'
 
 if (Platform.OS === 'ios') {
   Mapbox.setWellKnownTileServer('mapbox')
@@ -25,6 +26,9 @@ export default function MapboxMapWithQSOs ({ styles, mappableQSOs, initialRegion
   }
 
   const qsosGeoJSON = useMemo(() => _geoJSONMarkersForQSOs({ mappableQSOs, qth, operation, styles }), [mappableQSOs, qth, operation, styles])
+  const originsGeoJSON = useMemo(() => buildOriginFeatureCollection({ mappableQSOs, styles }), [mappableQSOs, styles])
+  const originGroups = useMemo(() => buildOriginGroups({ mappableQSOs, styles }), [mappableQSOs, styles])
+  const numberedOriginGroups = useMemo(() => originGroups.filter(group => group.order), [originGroups])
   const linesGeoJSON = useMemo(() => _getJSONLinesForQSOs({ mappableQSOs, qth, operation, styles }), [mappableQSOs, qth, operation, styles])
 
   const circleStyles = useMemo(() => {
@@ -84,6 +88,23 @@ export default function MapboxMapWithQSOs ({ styles, mappableQSOs, initialRegion
       setSelectedFeature(null)
     }
   }, [selectedFeature])
+
+  const handleOriginMarkerPress = useCallback((group) => {
+    setSelectedFeature({
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: group.coordinates
+      },
+      properties: {
+        markerType: 'origin',
+        color: group.color,
+        strengthFactor: 1,
+        orderLabel: group.order ? String(group.order) : '',
+        callout: `Origin: ${group.grid || group.coordinates.join(', ')}`
+      }
+    })
+  }, [])
 
   const mapRef = useRef()
   const [camera, setCamera] = useState(null)
@@ -149,6 +170,48 @@ export default function MapboxMapWithQSOs ({ styles, mappableQSOs, initialRegion
             <CircleLayer id="qsos-circles" style={circleStyles} layerIndex={100} />
           </ShapeSource>
         )}
+        {originsGeoJSON && numberedOriginGroups.length === 0 && (
+          <ShapeSource id="origins-source" shape={originsGeoJSON} onPress={handleMapPress}>
+            <CircleLayer id="origin-circles" style={circleStyles} layerIndex={100} />
+          </ShapeSource>
+        )}
+        {numberedOriginGroups.map(group => (
+          <MarkerView
+            key={group.key}
+            coordinate={group.coordinates}
+            anchor={{ x: 0.5, y: 0.5 }}
+            allowOverlap={true}
+            allowOverlapWithPuck={true}
+          >
+            <Pressable
+              onPress={() => handleOriginMarkerPress(group)}
+              style={{
+                width: styles.oneSpace * 2.5,
+                height: styles.oneSpace * 2.5,
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: styles.oneSpace * 1.25,
+                borderWidth: 2,
+                borderColor: '#FFFFFF',
+                backgroundColor: group.color
+              }}
+            >
+              <Text
+                style={{
+                  color: '#FFFFFF',
+                  fontSize: 11,
+                  fontWeight: '900',
+                  lineHeight: 13,
+                  textShadowColor: '#000000',
+                  textShadowOffset: { width: 0, height: 1 },
+                  textShadowRadius: 2
+                }}
+              >
+                {group.order}
+              </Text>
+            </Pressable>
+          </MarkerView>
+        ))}
         {linesGeoJSON && (
           <ShapeSource id="qsos-lines-source" shape={linesGeoJSON} onPress={handleMapPress}>
             <LineLayer id="qsos-lines" style={linesStyles} layerIndex={99} />
@@ -193,7 +256,6 @@ const FeatureCallout = ({ feature, qth, operation, styles }) => {
 function _geoJSONMarkersForQSOs ({ mappableQSOs, qth, operation, styles }) {
   const features = []
   features.push(...mappableQSOs.map(mappableQSO => _geoJSONMarkerForQSO({ mappableQSO, qth, operation, styles })).filter(x => x))
-  features.push(..._geoJSONMarkersForOrigins({ mappableQSOs, styles }))
 
   return {
     type: 'FeatureCollection',
@@ -207,7 +269,7 @@ function _geoJSONMarkerForQSO ({ mappableQSO, qth, operation, styles }) {
       type: 'Feature',
       geometry: {
         type: 'Point',
-        coordinates: _coordsFromLatLon(mappableQSO.location)
+        coordinates: coordsFromLatLon(mappableQSO.location)
       },
       properties: {
         color: styles.colors.bands[mappableQSO.qso.band] || styles.colors.bands.default,
@@ -217,34 +279,6 @@ function _geoJSONMarkerForQSO ({ mappableQSO, qth, operation, styles }) {
       }
     }
   }
-}
-
-function _geoJSONMarkersForOrigins ({ mappableQSOs, styles }) {
-  const seen = new Set()
-
-  return mappableQSOs.map(mappableQSO => {
-    const origin = mappableQSO?.ourLocation
-    if (origin?.latitude === undefined || origin?.longitude === undefined) return null
-
-    const coordinates = _coordsFromLatLon(origin)
-    const originGrid = mappableQSO.ourGrid
-    const key = originGrid || coordinates.join(',')
-    if (seen.has(key)) return null
-    seen.add(key)
-
-    return {
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates
-      },
-      properties: {
-        color: styles.colors.bands.other,
-        strengthFactor: 1,
-        callout: `Origin: ${originGrid || coordinates.join(', ')}`
-      }
-    }
-  }).filter(x => x)
 }
 
 function _getJSONLinesForQSOs ({ mappableQSOs, qth, operation, styles }) {
@@ -261,8 +295,8 @@ function _geoJSONLineForQSO ({ mappableQSO, qth, operation, styles }) {
     const ourLocation = mappableQSO?.ourLocation ?? qth
     if (ourLocation?.latitude === undefined || ourLocation?.longitude === undefined) return null
 
-    const start = _coordsFromLatLon(mappableQSO.location)
-    const end = _coordsFromLatLon(ourLocation)
+    const start = coordsFromLatLon(mappableQSO.location)
+    const end = coordsFromLatLon(ourLocation)
 
     if (start[0] === end[0] && start[1] === end[1]) {
       return null
@@ -279,10 +313,6 @@ function _geoJSONLineForQSO ({ mappableQSO, qth, operation, styles }) {
       }
     }))
   }
-}
-
-function _coordsFromLatLon ({ latitude, longitude }) {
-  return [Number(longitude?.toFixed(5) ?? 0), Number(latitude?.toFixed(5) ?? 0)]
 }
 
 function _colorForText ({ qso, styles, mapStyles }) {

--- a/src/screens/OperationScreens/OpMapTab/components/MapboxMapWithQSOs.jsx
+++ b/src/screens/OperationScreens/OpMapTab/components/MapboxMapWithQSOs.jsx
@@ -101,7 +101,7 @@ export default function MapboxMapWithQSOs ({ styles, mappableQSOs, initialRegion
         color: group.color,
         strengthFactor: 1,
         orderLabel: group.order ? String(group.order) : '',
-        callout: `Origin: ${group.grid || group.coordinates.join(', ')}`
+        callout: group.callout
       }
     })
   }, [])

--- a/src/screens/OperationScreens/OpMapTab/components/MapboxMapWithQSOs.jsx
+++ b/src/screens/OperationScreens/OpMapTab/components/MapboxMapWithQSOs.jsx
@@ -190,30 +190,10 @@ const FeatureCallout = ({ feature, qth, operation, styles }) => {
   }
 }
 
-function _geoJSONMarkerForQTH ({ qth, operation, styles }) {
-  if (qth?.latitude !== undefined && qth?.longitude !== undefined) {
-    return {
-      type: 'Feature',
-      geometry: {
-        type: 'Point',
-        coordinates: _coordsFromLatLon(qth)
-      },
-      properties: {
-        color: styles.colors.bands.other,
-        strenghtFactor: 1,
-        callout: `QTH: ${operation.grid}`
-      }
-    }
-  }
-}
-
 function _geoJSONMarkersForQSOs ({ mappableQSOs, qth, operation, styles }) {
   const features = []
   features.push(...mappableQSOs.map(mappableQSO => _geoJSONMarkerForQSO({ mappableQSO, qth, operation, styles })).filter(x => x))
-
-  if (qth?.latitude !== undefined && qth?.longitude !== undefined) {
-    features.push(_geoJSONMarkerForQTH({ qth, operation, styles }))
-  }
+  features.push(..._geoJSONMarkersForOrigins({ mappableQSOs, styles }))
 
   return {
     type: 'FeatureCollection',
@@ -239,21 +219,50 @@ function _geoJSONMarkerForQSO ({ mappableQSO, qth, operation, styles }) {
   }
 }
 
-function _getJSONLinesForQSOs ({ mappableQSOs, qth, operation, styles }) {
-  if (qth?.latitude !== undefined && qth?.longitude !== undefined) {
-    const features = mappableQSOs.map(mappableQSO => _geoJSONLineForQSO({ mappableQSO, qth, operation, styles })).flat().filter(x => x)
+function _geoJSONMarkersForOrigins ({ mappableQSOs, styles }) {
+  const seen = new Set()
+
+  return mappableQSOs.map(mappableQSO => {
+    const origin = mappableQSO?.ourLocation
+    if (origin?.latitude === undefined || origin?.longitude === undefined) return null
+
+    const coordinates = _coordsFromLatLon(origin)
+    const originGrid = mappableQSO.ourGrid
+    const key = originGrid || coordinates.join(',')
+    if (seen.has(key)) return null
+    seen.add(key)
 
     return {
-      type: 'FeatureCollection',
-      features
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates
+      },
+      properties: {
+        color: styles.colors.bands.other,
+        strengthFactor: 1,
+        callout: `Origin: ${originGrid || coordinates.join(', ')}`
+      }
     }
+  }).filter(x => x)
+}
+
+function _getJSONLinesForQSOs ({ mappableQSOs, qth, operation, styles }) {
+  const features = mappableQSOs.map(mappableQSO => _geoJSONLineForQSO({ mappableQSO, qth, operation, styles })).flat().filter(x => x)
+
+  return {
+    type: 'FeatureCollection',
+    features
   }
 }
 
 function _geoJSONLineForQSO ({ mappableQSO, qth, operation, styles }) {
   if (mappableQSO?.location?.latitude !== undefined && mappableQSO?.location?.longitude !== undefined) {
+    const ourLocation = mappableQSO?.ourLocation ?? qth
+    if (ourLocation?.latitude === undefined || ourLocation?.longitude === undefined) return null
+
     const start = _coordsFromLatLon(mappableQSO.location)
-    const end = _coordsFromLatLon(qth)
+    const end = _coordsFromLatLon(ourLocation)
 
     if (start[0] === end[0] && start[1] === end[1]) {
       return null

--- a/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.js
+++ b/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.js
@@ -1,0 +1,70 @@
+// Copyright ©️ 2026 Sebastian Delmont <sd@ham2k.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export function coordsFromLatLon ({ latitude, longitude }) {
+  return [Number(longitude?.toFixed(5) ?? 0), Number(latitude?.toFixed(5) ?? 0)]
+}
+
+export function buildOriginGroups ({ mappableQSOs, styles }) {
+  const byKey = new Map()
+
+  for (const mappableQSO of mappableQSOs) {
+    const origin = mappableQSO?.ourLocation
+    if (origin?.latitude === undefined || origin?.longitude === undefined) continue
+
+    const coordinates = coordsFromLatLon(origin)
+    const grid = mappableQSO.ourGrid
+    const key = grid || coordinates.join(',')
+    const startAtMillis = mappableQSO.qso?.startAtMillis ?? Number.MAX_SAFE_INTEGER
+
+    const existing = byKey.get(key)
+    if (existing) {
+      existing.qsoCount += 1
+      existing.firstQSOAtMillis = Math.min(existing.firstQSOAtMillis, startAtMillis)
+      existing.qsos.push(mappableQSO.qso)
+    } else {
+      byKey.set(key, {
+        key,
+        grid,
+        coordinates,
+        qsoCount: 1,
+        firstQSOAtMillis: startAtMillis,
+        qsos: [mappableQSO.qso],
+        color: styles.colors.bands.other
+      })
+    }
+  }
+
+  const groups = [...byKey.values()].sort((a, b) => {
+    if (a.firstQSOAtMillis !== b.firstQSOAtMillis) return a.firstQSOAtMillis - b.firstQSOAtMillis
+    return a.key.localeCompare(b.key)
+  })
+
+  if (groups.length > 1) {
+    groups.forEach((group, index) => {
+      group.order = index + 1
+    })
+  }
+
+  return groups
+}
+
+export function buildOriginFeatureCollection ({ mappableQSOs, styles }) {
+  return {
+    type: 'FeatureCollection',
+    features: buildOriginGroups({ mappableQSOs, styles }).map(group => ({
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: group.coordinates
+      },
+      properties: {
+        markerType: 'origin',
+        color: group.color,
+        strengthFactor: 1,
+        orderLabel: group.order ? String(group.order) : '',
+        callout: `Origin: ${group.grid || group.coordinates.join(', ')}`
+      }
+    }))
+  }
+}

--- a/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.js
+++ b/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.js
@@ -1,6 +1,8 @@
 // Copyright ©️ 2026 Sebastian Delmont <sd@ham2k.com>
 // SPDX-License-Identifier: MPL-2.0
 
+import { fmtTimeBetween } from '@ham2k/lib-format-tools'
+
 export function coordsFromLatLon ({ latitude, longitude }) {
   return [Number(longitude?.toFixed(5) ?? 0), Number(latitude?.toFixed(5) ?? 0)]
 }
@@ -21,7 +23,9 @@ export function buildOriginGroups ({ mappableQSOs, styles }) {
     if (existing) {
       existing.qsoCount += 1
       existing.firstQSOAtMillis = Math.min(existing.firstQSOAtMillis, startAtMillis)
+      existing.lastQSOAtMillis = Math.max(existing.lastQSOAtMillis, startAtMillis)
       existing.qsos.push(mappableQSO.qso)
+      if (!existing.originRef) existing.originRef = firstDisplayRef(mappableQSO.originRefs)
     } else {
       byKey.set(key, {
         key,
@@ -29,7 +33,9 @@ export function buildOriginGroups ({ mappableQSOs, styles }) {
         coordinates,
         qsoCount: 1,
         firstQSOAtMillis: startAtMillis,
+        lastQSOAtMillis: startAtMillis,
         qsos: [mappableQSO.qso],
+        originRef: firstDisplayRef(mappableQSO.originRefs),
         color: styles.colors.bands.other
       })
     }
@@ -45,6 +51,10 @@ export function buildOriginGroups ({ mappableQSOs, styles }) {
       group.order = index + 1
     })
   }
+
+  groups.forEach(group => {
+    group.callout = calloutForOriginGroup(group)
+  })
 
   return groups
 }
@@ -63,8 +73,32 @@ export function buildOriginFeatureCollection ({ mappableQSOs, styles }) {
         color: group.color,
         strengthFactor: 1,
         orderLabel: group.order ? String(group.order) : '',
-        callout: `Origin: ${group.grid || group.coordinates.join(', ')}`
+        callout: group.callout
       }
     }))
   }
+}
+
+export function calloutForOriginGroup (group) {
+  const label = labelForOriginGroup(group)
+  const qsoLabel = group.qsoCount === 1 ? '1 QSO' : `${group.qsoCount} QSOs`
+  const durationLabel = durationForOriginGroup(group)
+  return `${label}\n${[qsoLabel, durationLabel].filter(Boolean).join(' • ')}`
+}
+
+function labelForOriginGroup (group) {
+  const ref = group.originRef
+  if (ref?.ref && ref?.name) return `${ref.ref}: ${ref.name}`
+  if (ref?.ref) return ref.ref
+  return group.grid || group.coordinates.join(', ')
+}
+
+function firstDisplayRef (refs) {
+  return refs?.find(ref => ref?.ref)
+}
+
+function durationForOriginGroup (group) {
+  if (!Number.isFinite(group.firstQSOAtMillis) || !Number.isFinite(group.lastQSOAtMillis)) return ''
+  if (group.firstQSOAtMillis === group.lastQSOAtMillis) return ''
+  return fmtTimeBetween(group.firstQSOAtMillis, group.lastQSOAtMillis, { roundTo: 'minutes' })
 }

--- a/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.spec.js
+++ b/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.spec.js
@@ -9,11 +9,12 @@ describe('buildOriginGroups', () => {
     }
   }
 
-  function mappableQSO ({ uuid, grid, latitude, longitude, startAtMillis }) {
+  function mappableQSO ({ uuid, grid, latitude, longitude, startAtMillis, originRefs }) {
     return {
       qso: { uuid, startAtMillis },
       ourGrid: grid,
-      ourLocation: { latitude, longitude }
+      ourLocation: { latitude, longitude },
+      originRefs
     }
   }
 
@@ -57,5 +58,42 @@ describe('buildOriginGroups', () => {
 
     expect(geoJSON.features.map(feature => feature.properties.orderLabel)).toEqual(['1', '2'])
     expect(geoJSON.features.map(feature => feature.properties.markerType)).toEqual(['origin', 'origin'])
+  })
+
+  it('builds callouts with generic ref label, QSO count, and first-to-last duration', () => {
+    const geoJSON = buildOriginFeatureCollection({
+      mappableQSOs: [
+        mappableQSO({
+          uuid: 'later',
+          grid: 'FM18',
+          latitude: 38.9,
+          longitude: -77,
+          startAtMillis: Date.UTC(2026, 0, 1, 12, 15),
+          originRefs: [{ type: 'genericActivation', ref: 'GEN-002', name: 'Second Place' }]
+        }),
+        mappableQSO({
+          uuid: 'first',
+          grid: 'FM19',
+          latitude: 39.1,
+          longitude: -76.8,
+          startAtMillis: Date.UTC(2026, 0, 1, 12, 0),
+          originRefs: [{ type: 'genericActivation', ref: 'GEN-001', name: 'First Place' }]
+        }),
+        mappableQSO({
+          uuid: 'same-origin',
+          grid: 'FM18',
+          latitude: 38.9,
+          longitude: -77,
+          startAtMillis: Date.UTC(2026, 0, 1, 12, 30),
+          originRefs: [{ type: 'genericActivation', ref: 'GEN-002', name: 'Second Place' }]
+        })
+      ],
+      styles
+    })
+
+    expect(geoJSON.features.map(feature => feature.properties.callout)).toEqual([
+      'GEN-001: First Place\n1 QSO',
+      'GEN-002: Second Place\n2 QSOs • 15m'
+    ])
   })
 })

--- a/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.spec.js
+++ b/src/screens/OperationScreens/OpMapTab/components/mapOriginGroups.spec.js
@@ -1,0 +1,61 @@
+import { buildOriginFeatureCollection, buildOriginGroups } from './mapOriginGroups'
+
+describe('buildOriginGroups', () => {
+  const styles = {
+    colors: {
+      bands: { other: '#111111' },
+      onSurface: '#ffffff',
+      outline: '#dddddd'
+    }
+  }
+
+  function mappableQSO ({ uuid, grid, latitude, longitude, startAtMillis }) {
+    return {
+      qso: { uuid, startAtMillis },
+      ourGrid: grid,
+      ourLocation: { latitude, longitude }
+    }
+  }
+
+  it('deduplicates origins by grid and orders by first QSO time', () => {
+    const groups = buildOriginGroups({
+      mappableQSOs: [
+        mappableQSO({ uuid: 'later', grid: 'FM18', latitude: 38.9, longitude: -77, startAtMillis: 3000 }),
+        mappableQSO({ uuid: 'first', grid: 'FM19', latitude: 39.1, longitude: -76.8, startAtMillis: 1000 }),
+        mappableQSO({ uuid: 'same-origin', grid: 'FM18', latitude: 38.9, longitude: -77, startAtMillis: 2000 })
+      ],
+      styles
+    })
+
+    expect(groups.map(group => group.grid)).toEqual(['FM19', 'FM18'])
+    expect(groups.map(group => group.order)).toEqual([1, 2])
+    expect(groups.map(group => group.qsoCount)).toEqual([1, 2])
+  })
+
+  it('omits display order when there is only one origin', () => {
+    const groups = buildOriginGroups({
+      mappableQSOs: [
+        mappableQSO({ uuid: 'a', grid: 'FM19', latitude: 39.1, longitude: -76.8, startAtMillis: 1000 }),
+        mappableQSO({ uuid: 'b', grid: 'FM19', latitude: 39.1, longitude: -76.8, startAtMillis: 2000 })
+      ],
+      styles
+    })
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].order).toBeUndefined()
+    expect(groups[0].qsoCount).toBe(2)
+  })
+
+  it('builds origin GeoJSON features with order labels', () => {
+    const geoJSON = buildOriginFeatureCollection({
+      mappableQSOs: [
+        mappableQSO({ uuid: 'later', grid: 'FM18', latitude: 38.9, longitude: -77, startAtMillis: 3000 }),
+        mappableQSO({ uuid: 'first', grid: 'FM19', latitude: 39.1, longitude: -76.8, startAtMillis: 1000 })
+      ],
+      styles
+    })
+
+    expect(geoJSON.features.map(feature => feature.properties.orderLabel)).toEqual(['1', '2'])
+    expect(geoJSON.features.map(feature => feature.properties.markerType)).toEqual(['origin', 'origin'])
+  })
+})

--- a/src/tools/qsonToADIF.js
+++ b/src/tools/qsonToADIF.js
@@ -3,6 +3,7 @@
 
 import { escapeToUnicodeEntities, fmtADIFDate, fmtADIFTime, fmtISODateTime } from '@ham2k/lib-format-tools'
 import { adifModeAndSubmodeForMode, frequencyForBand, modeForFrequency } from '@ham2k/lib-operation-data'
+import { forEachQSOWithSectionContext } from '@ham2k/lib-qson-tools'
 
 import packageJson from '../../package.json'
 import { findBestHook } from '../extensions/registry'
@@ -48,8 +49,6 @@ export function qsonToADIF ({ operation, settings, qsos, handler, format, title,
     common.operatorCall = operation.local?.operatorCall || operation.operatorCall
   }
 
-  // const eventQSOs = qsos.filter(qso => qso.event && !qso.deleted)
-
   let str = ''
   str += `ADIF for ${title || ([common.stationCall, operation?.title, operation.subTitle].filter(x => x).join(' ')) || 'Operation'} \n`
   str += adifField('ADIF_VER', '3.1.5', { newLine: true })
@@ -65,115 +64,121 @@ export function qsonToADIF ({ operation, settings, qsos, handler, format, title,
 
   str += '<EOH>\n'
 
-  qsos.forEach(qso => {
-    if (qso.deleted) return
-    if (qso.event) {
-      if (privateData) {
-        if (qso.event.event === 'break' || qso.event.event === 'start') str += '\n'
+  forEachQSOWithSectionContext({
+    qsos,
+    operation,
+    withEvents: true,
+    callback: ({ qso, sectionRefs, sectionGrid }) => {
+      if (qso.deleted) return
+      if (qso.event) {
+        if (privateData) {
+          if (qso.event.event === 'break' || qso.event.event === 'start') str += '\n'
 
-        const eventRecord = `${fmtISODateTime(qso.startAtMillis)}: ${qso.event.note ?? qso.event.message ?? qso.event.description.replaceAll(/ • /g, ' * ')}`
-        str += adifField(`X_HAM2K_${qso.event.event?.toUpperCase() || 'EVENT'}`, eventRecord, { newLine: true })
+          const eventRecord = `${fmtISODateTime(qso.startAtMillis)}: ${qso.event.note ?? qso.event.message ?? qso.event.description.replaceAll(/ • /g, ' * ')}`
+          str += adifField(`X_HAM2K_${qso.event.event?.toUpperCase() || 'EVENT'}`, eventRecord, { newLine: true })
 
-        if (qso.event.data) {
-          str += adifField(`X_HAM2K_${qso.event.event?.toUpperCase() || 'EVENT'}_DATA`, JSON.stringify(qso.event.data), { newLine: true })
-        } else {
-          const dataField = Object.keys(qso.event).find(key => key.endsWith('Data'))
-          if (dataField) {
-            str += adifField(`X_HAM2K_${qso.event.event?.toUpperCase() || 'EVENT'}_DATA`, JSON.stringify(qso.event[dataField]), { newLine: true })
+          if (qso.event.data) {
+            str += adifField(`X_HAM2K_${qso.event.event?.toUpperCase() || 'EVENT'}_DATA`, JSON.stringify(qso.event.data), { newLine: true })
+          } else {
+            const dataField = Object.keys(qso.event).find(key => key.endsWith('Data'))
+            if (dataField) {
+              str += adifField(`X_HAM2K_${qso.event.event?.toUpperCase() || 'EVENT'}_DATA`, JSON.stringify(qso.event[dataField]), { newLine: true })
+            }
           }
+
+          if (qso.event.event === 'break' || qso.event.event === 'start') str += '\n'
         }
 
-        if (qso.event.event === 'break' || qso.event.event === 'start') str += '\n'
-      }
-
-      if (qso.event.event === 'break' || qso.event.event === 'start') {
-        if (combineSegmentRefs) {
-          // Update all operation attributes, including regs
-          operation = { ...operation, ...qso.event.operation }
-          common = { ...common, ...qso.event.operation }
-        } else {
+        if (qso.event.event === 'break' || qso.event.event === 'start') {
+          const segmentOperation = { ...qso.event.operation, refs: sectionRefs, grid: sectionGrid }
+          if (combineSegmentRefs) {
+          // Update all operation attributes, including refs
+            operation = { ...operation, ...segmentOperation }
+            common = { ...common, ...segmentOperation }
+          } else {
           // Combine other attributes, but keep refs as initialized
-          operation = { ...operation, ...qso.event.operation, refs: operation.refs }
-          common = { ...common, ...qso.event.operation, refs: common.refs }
+            operation = { ...operation, ...segmentOperation, refs: operation.refs }
+            common = { ...common, ...segmentOperation, refs: common.refs }
+          }
+          templates.context = templateContextForOneExport({ settings, operation, handler })
         }
-        templates.context = templateContextForOneExport({ settings, operation, handler })
+        return
       }
-      return
-    }
 
-    if (ignoreLookupData) {
-      // We can't just delete all of `guess` because it also contains callsign parsing info like `entityPrefix`, `entityName`, etc.
-      if (qso.their?.guess) {
-        qso = {
-          ...qso,
-          their: {
-            ...qso.their,
-            guess: {
-              ...qso.their.guess,
-              name: undefined,
-              city: undefined,
-              state: undefined,
-              county: undefined,
-              country: undefined,
-              grid: undefined,
-              lat: undefined,
-              lon: undefined
+      if (ignoreLookupData) {
+        // We can't just delete all of `guess` because it also contains callsign parsing info like `entityPrefix`, `entityName`, etc.
+        if (qso.their?.guess) {
+          qso = {
+            ...qso,
+            their: {
+              ...qso.their,
+              guess: {
+                ...qso.their.guess,
+                name: undefined,
+                city: undefined,
+                state: undefined,
+                county: undefined,
+                country: undefined,
+                grid: undefined,
+                lat: undefined,
+                lon: undefined
+              }
             }
           }
         }
       }
-    }
 
-    // Get the base handler's field combinations for this QSO
-    // it might return an array of arrays,
-    // meaning this QSO has to be represented by multiple ADIF rows (think POTA P2P, or QSO Party county line operations)
-    let handlerFieldCombinations
-    if (handler?.adifFieldCombinationsForOneQSO) {
-      handlerFieldCombinations = handler.adifFieldCombinationsForOneQSO({ qso, operation, common, exportType, mainHandler: true, privateData, templates })
-    } else if (handler?.adifFieldsForOneQSO) {
-      handlerFieldCombinations = [handler.adifFieldsForOneQSO({ qso, operation, common, exportType, mainHandler: true, templates, privateData })]
-    } else {
-      handlerFieldCombinations = [[]]
-    }
-
-    if (handlerFieldCombinations === false || handlerFieldCombinations[0] === false) return
-
-    // Now, for each field combination, we will generate an ADIF row
-    handlerFieldCombinations.forEach((combinationFields, n) => {
-      // We start with the general ADIF fields
-      let fields = adifFieldsForOneQSO({ qso, operation, common, privateData, templates, timeOffset: n * 1000 })
-      // Then we append the fields from the main handler's combinations
-      fields = fields.concat(combinationFields)
-
-      if (includeOtherRefs) {
-        // And finally, we look at any handlers for other refs in the operation, or refs in the QSO itself
-        // and ask them for more fields to add to this QSO.
-        const refs = [...qso.refs || [], ...operation.refs || []]
-        refs.filter(ref => ref.type).forEach(ref => {
-          const secondaryRefHandler = findBestHook(`ref:${ref.type}`)
-
-          if (secondaryRefHandler?.key === handler.key) return // Skip if it happens to be the same as the main handler
-
-          if (secondaryRefHandler && secondaryRefHandler.key !== handler.key && secondaryRefHandler.adifFieldsForOneQSO) {
-            const refFields = secondaryRefHandler.adifFieldsForOneQSO({ qso, operation, common, exportType, ref, privateData, templates }) || []
-            refFields.forEach(refField => {
-              const existingField = fields.find(field => Object.keys(field)[0] === Object.keys(refField)[0])
-              if (existingField) {
-                // If another field with the same name already exists. Keep the first one defined and ignore this one
-                // unless it is `false`, in which case the field should be removed.
-                if (refField[1] === false) {
-                  existingField[1] = false
-                }
-              } else {
-                fields = fields.concat([refField])
-              }
-            })
-          }
-        })
+      // Get the base handler's field combinations for this QSO
+      // it might return an array of arrays,
+      // meaning this QSO has to be represented by multiple ADIF rows (think POTA P2P, or QSO Party county line operations)
+      let handlerFieldCombinations
+      if (handler?.adifFieldCombinationsForOneQSO) {
+        handlerFieldCombinations = handler.adifFieldCombinationsForOneQSO({ qso, operation, common, exportType, mainHandler: true, privateData, templates })
+      } else if (handler?.adifFieldsForOneQSO) {
+        handlerFieldCombinations = [handler.adifFieldsForOneQSO({ qso, operation, common, exportType, mainHandler: true, templates, privateData })]
+      } else {
+        handlerFieldCombinations = [[]]
       }
 
-      str += adifRow(fields)
-    })
+      if (handlerFieldCombinations === false || handlerFieldCombinations[0] === false) return
+
+      // Now, for each field combination, we will generate an ADIF row
+      handlerFieldCombinations.forEach((combinationFields, n) => {
+      // We start with the general ADIF fields
+        let fields = adifFieldsForOneQSO({ qso, operation, common, privateData, templates, timeOffset: n * 1000 })
+        // Then we append the fields from the main handler's combinations
+        fields = fields.concat(combinationFields)
+
+        if (includeOtherRefs) {
+        // And finally, we look at any handlers for other refs in the operation, or refs in the QSO itself
+        // and ask them for more fields to add to this QSO.
+          const refs = [...qso.refs || [], ...operation.refs || []]
+          refs.filter(ref => ref.type).forEach(ref => {
+            const secondaryRefHandler = findBestHook(`ref:${ref.type}`)
+
+            if (secondaryRefHandler?.key === handler.key) return // Skip if it happens to be the same as the main handler
+
+            if (secondaryRefHandler && secondaryRefHandler.key !== handler.key && secondaryRefHandler.adifFieldsForOneQSO) {
+              const refFields = secondaryRefHandler.adifFieldsForOneQSO({ qso, operation, common, exportType, ref, privateData, templates }) || []
+              refFields.forEach(refField => {
+                const existingField = fields.find(field => Object.keys(field)[0] === Object.keys(refField)[0])
+                if (existingField) {
+                // If another field with the same name already exists. Keep the first one defined and ignore this one
+                // unless it is `false`, in which case the field should be removed.
+                  if (refField[1] === false) {
+                    existingField[1] = false
+                  }
+                } else {
+                  fields = fields.concat([refField])
+                }
+              })
+            }
+          })
+        }
+
+        str += adifRow(fields)
+      })
+    }
   })
 
   return str


### PR DESCRIPTION
**BLUF:** Make roving map origins easier to identify by numbering each origin marker and showing richer origin callouts.

This assigns each unique origin grid an order number based on the first QSO from that origin. Multi-origin operations render those origins as small tappable numbered markers so the sequence remains visible on the map.

Origin callouts now use the active activation ref when available, falling back to the grid or coordinates. They also show the QSO count and the first-to-last QSO duration for that origin when multiple timestamps are available.

## Scope

- Deduplicate origins by active origin grid/location.
- Order origins by first QSO time.
- Render numbered origin markers for multi-origin maps.
- Keep the existing single-origin dot behavior when there is only one
  origin.
- Show generic activation ref/name, QSO count, and elapsed QSO span in
  origin callouts.

## Stack

1. **main**
2. https://github.com/ham2k/app-polo/pull/204
3. 👉 `rwjblue/number-map-origin-dots`

This draft currently depends on the preceding roving-map stack because
GitHub does not expose fork PR head branches as base branches in the
upstream repository. After the prior PR lands, this PR should be rebased
so the diff contains only the origin marker and callout changes.

## Screenshots

<img height="300" alt="2026-06-13 at 19 03 51" src="https://github.com/user-attachments/assets/a2e507d8-a677-4ab7-954f-b9ac0d240344" />

### Multi location

<img height="300" alt="image" src="https://github.com/user-attachments/assets/4f4e6bcb-2929-4bbe-b780-6f5fa58684e6" />

<img height="282" alt="2026-06-13 at 19 09 11" src="https://github.com/user-attachments/assets/66381d88-dfbc-4abf-8f6e-2ab137cb6e8e" />

### Single Location

<img height="300" alt="image" src="https://github.com/user-attachments/assets/f8112e71-81da-414b-aff7-71fb216b1a72" />

<img height="288" alt="2026-06-13 at 19 10 53" src="https://github.com/user-attachments/assets/45ab3970-de0f-4472-b345-c6ddd3b818de" />


