### PR TITLE
Add sticky segment headers

### DIFF
--- a/src/extensions/scoring/index.js
+++ b/src/extensions/scoring/index.js
@@ -59,6 +59,76 @@ export function scoringHandlersForOperation ({ operation }) {
   return scoringHandlers.sort((a, b) => b.priority - a.priority)
 }
 
+/**
+ * Builds the compact scoring payload used by QSO list headers.
+ *
+ * The summary is scoped by `qsos`: only non-deleted, non-event QSOs in that
+ * array contribute to the returned `count` and accumulated `scores`.
+ *
+ * `operationQSOs` is the broader operation log passed through to scoring
+ * handlers as `qsos`. This keeps existing duplicate/history logic intact for
+ * handlers that need to inspect contacts outside the header's local scope, such
+ * as contest scorers, while still allowing segment headers to count only their
+ * own QSOs.
+ *
+ * Returns:
+ *   {
+ *     count: number,
+ *     scores: {
+ *       [scoreKey: string]: object
+ *     }
+ *   }
+ */
+export function buildHeaderSummary ({ qsos, operationQSOs, operation, ourInfo, scoringHandlers }) {
+  const t = GLOBAL?.t
+
+  qsos = qsos ?? []
+  operationQSOs = operationQSOs ?? qsos
+  operation = operation ?? {}
+  scoringHandlers = scoringHandlers ?? scoringHandlersForOperation({ operation })
+
+  const summary = { count: 0, scores: {} }
+
+  scoringHandlers.forEach(({ handler, ref }) => {
+    const key = ref?.type ?? handler.key
+    summary.scores[key] = {}
+  })
+
+  qsos.forEach(qso => {
+    if (qso.deleted || qso.event) return
+
+    summary.count = summary.count + 1
+
+    scoringHandlers.forEach(({ handler, ref }) => {
+      const key = ref?.type ?? handler.key
+      try {
+        const qsoScore = handler.scoringForQSO({ qso, qsos: operationQSOs, score: summary.scores[key], operation, ref, ourInfo })
+
+        if (handler.accumulateScoreForDay) {
+          summary.scores[key] = handler.accumulateScoreForDay({ qsoScore, score: summary.scores[key], operation, ref })
+        } else if (handler.accumulateScoreForOperation) {
+          summary.scores[key] = handler.accumulateScoreForOperation({ qsoScore, score: summary.scores[key], operation, ref })
+        }
+      } catch (e) {
+        reportError(`Error accumulating header summary score for '${handler.key}' and qso '${qso.key}'`, e)
+      }
+    })
+  })
+
+  scoringHandlers.forEach(({ handler, ref }) => {
+    const key = ref?.type ?? handler.key
+    if (handler.summarizeScore && summary.scores[key]) {
+      try {
+        summary.scores[key] = handler.summarizeScore({ t, score: summary.scores[key] ?? {}, operation, ref, section: summary })
+      } catch (e) {
+        reportError(`Error summarizing header summary score for '${handler.key}'`, e)
+      }
+    }
+  })
+
+  return summary
+}
+
 export function analyzeAndSectionQSOs ({ qsos, operation, ourInfo, showDeletedQSOs = true }) {
   const t = GLOBAL?.t
 
@@ -76,6 +146,25 @@ export function analyzeAndSectionQSOs ({ qsos, operation, ourInfo, showDeletedQS
   let currentSection = null
   let currentBreakEvent = null
   let currentOperation = operation
+  let currentSegment
+  let currentSegmentHandlers = scoringHandlers
+
+  const resetSegment = ({ event, segmentOperation, segmentScoringHandlers }) => {
+    currentSegment = { event, operation: segmentOperation, qsos: [] }
+    currentSegmentHandlers = segmentScoringHandlers
+  }
+
+  const summarizeSegment = () => {
+    if (!currentSegment) return
+
+    currentSegment.event.segmentSummary = buildHeaderSummary({
+      qsos: currentSegment.qsos,
+      operationQSOs: qsos,
+      operation: currentSegment.operation,
+      ourInfo,
+      scoringHandlers: currentSegmentHandlers
+    })
+  }
 
   for (const qso of qsos) {
     if (showDeletedQSOs === false && qso.deleted) continue
@@ -119,17 +208,23 @@ export function analyzeAndSectionQSOs ({ qsos, operation, ourInfo, showDeletedQS
     } else if (qso.event) {
       currentSection.events = (currentSection.events || 0) + 1
       if (qso.event.event === 'break' || qso.event.event === 'start') {
+        summarizeSegment()
+
         currentBreakEvent = qso.event
         currentOperation = { ...operation, ...currentBreakEvent?.operation }
 
         if (VERBOSE) console.log('\nOperation Break', qso.event)
 
         scoringHandlers = scoringHandlersForOperation({ operation: currentOperation })
+        resetSegment({ event: currentBreakEvent, segmentOperation: currentOperation, segmentScoringHandlers: scoringHandlers })
 
         if (VERBOSE) console.log('-- New scoring handlers', scoringHandlers.map(({ handler, ref }) => (`${handler.key} ${ref.ref ?? ref.location ?? ref.type ?? '-'}`)).join(', '))
       }
     } else {
       currentSection.count = (currentSection.count || 0) + 1
+      if (currentSegment) {
+        currentSegment.qsos.push(qso)
+      }
 
       if (VERBOSE >= 1) console.log('\nScoring qso', qso.key, { refs: qso.refs })
 
@@ -155,6 +250,7 @@ export function analyzeAndSectionQSOs ({ qsos, operation, ourInfo, showDeletedQS
 
   // Summarize last section
   if (VERBOSE) console.log('Summarizing last section')
+  summarizeSegment()
   scoringHandlers.forEach(({ handler, ref }) => {
     const key = ref?.type ?? handler.key
     if (VERBOSE >= 2 && DEBUG_KEYS.includes(handler.key)) console.log(`-- ${handler.key}${handler.key !== key ? ` (${key})` : ' '} ${ref.ref ?? ref.location ?? ref.type}`, { ...currentSection?.scores?.[key] })

--- a/src/extensions/scoring/index.spec.js
+++ b/src/extensions/scoring/index.spec.js
@@ -1,0 +1,123 @@
+// Copyright ©️ 2026 Robert Jackson <me@rwjblue.com>
+// SPDX-License-Identifier: MPL-2.0
+
+jest.mock('../registry', () => ({
+  findBestHook: jest.fn(),
+  findHooks: jest.fn(() => [])
+}))
+
+jest.mock('@ham2k/lib-operation-data', () => ({
+  BANDS: ['20m']
+}))
+
+jest.mock('../../distro', () => ({
+  reportError: jest.fn()
+}))
+
+const { analyzeAndSectionQSOs, buildHeaderSummary } = require('./index')
+
+const DAY = 24 * 60 * 60 * 1000
+
+function qso (uuid, startAtMillis) {
+  return {
+    uuid,
+    startAtMillis,
+    their: { call: uuid.toUpperCase() },
+    band: '20m',
+    mode: 'CW'
+  }
+}
+
+function segmentEvent (uuid, startAtMillis, event = 'break') {
+  return {
+    uuid,
+    startAtMillis,
+    band: 'event',
+    their: { call: uuid.toUpperCase() },
+    event: {
+      event,
+      operation: { grid: uuid }
+    }
+  }
+}
+
+describe('analyzeAndSectionQSOs segment summaries', () => {
+  test('builds header counts from qsos while scoring against operationQSOs', () => {
+    const scoringForQSO = jest.fn(({ qsos }) => ({ operationQSOCount: qsos.length }))
+    const accumulateScoreForOperation = jest.fn(({ qsoScore, score }) => ({
+      operationQSOCounts: [...(score.operationQSOCounts ?? []), qsoScore.operationQSOCount]
+    }))
+
+    const summary = buildHeaderSummary({
+      qsos: [qso('a', 2000)],
+      operationQSOs: [
+        segmentEvent('start-grid', 1000, 'start'),
+        qso('a', 2000),
+        qso('b', 3000)
+      ],
+      operation: {},
+      scoringHandlers: [{
+        ref: { type: 'test' },
+        handler: {
+          key: 'test',
+          scoringForQSO,
+          accumulateScoreForOperation
+        }
+      }]
+    })
+
+    expect(summary).toMatchInlineSnapshot(`
+      {
+        "count": 1,
+        "scores": {
+          "test": {
+            "operationQSOCounts": [
+              3,
+            ],
+          },
+        },
+      }
+    `)
+  })
+
+  test('attaches segment QSO counts to start and break events', () => {
+    const start = segmentEvent('start-grid', 1000, 'start')
+    const brk = segmentEvent('break-grid', 4000, 'break')
+
+    analyzeAndSectionQSOs({
+      operation: {},
+      qsos: [
+        start,
+        qso('a', 2000),
+        qso('b', 3000),
+        brk,
+        qso('c', 5000)
+      ]
+    })
+
+    expect([
+      start.event.segmentSummary?.count,
+      brk.event.segmentSummary?.count
+    ]).toMatchInlineSnapshot(`
+      [
+        2,
+        1,
+      ]
+    `)
+  })
+
+  test('carries segment summaries across day boundaries', () => {
+    const brk = segmentEvent('break-grid', DAY - 1000, 'break')
+
+    analyzeAndSectionQSOs({
+      operation: {},
+      qsos: [
+        brk,
+        qso('a', DAY + 1000),
+        qso('b', DAY + 2000)
+      ]
+    })
+
+    expect(brk.event.segmentSummary?.count).toBe(2)
+  })
+})

--- a/src/screens/OperationScreens/OpLoggingTab/components/QSOList.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/QSOList.jsx
@@ -5,7 +5,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { PixelRatio, View } from 'react-native'
 import { Text } from 'react-native-paper'
 import { useSafeAreaFrame, useSafeAreaInsets } from 'react-native-safe-area-context'
-import getItemLayout from 'react-native-get-item-layout-section-list'
 import { useTranslation } from 'react-i18next'
 
 import { fmtFreq, fmtShortTimeZulu, fmtTimeZulu } from '@ham2k/lib-format-tools'
@@ -20,6 +19,7 @@ import EventNoteItem from './entries/EventNoteItem'
 import EventSegmentItem from './entries/EventSegmentItem'
 import { SectionFlashList } from '../../../components/SectionFlashList'
 import { useScreenReaderEnabled } from '../../../../tools/a11yTools'
+import { hasMultipleSegmentsForQSOs, isActiveSegmentEvent } from './QSOListTools'
 
 const QSOList = React.memo(function QSOList ({ style, ourInfo, settings, qsos, sections, operation, vfo, onHeaderPress, lastUUID, selectedUUID, onSelectQSO }) {
   const { t } = useTranslation()
@@ -172,10 +172,11 @@ const QSOList = React.memo(function QSOList ({ style, ourInfo, settings, qsos, s
     )
   }, [operation, settings, selectedUUID, ourInfo, handlePress, timeFormatFunction, refHandlers, styles])
 
-  const renderHeader = useCallback(({ section, index }) => {
+  const renderHeader = useCallback(({ section, contextItem, headerType, target }) => {
     return (
       <QSOHeader
         section={section}
+        contextItem={contextItem}
         operation={operation}
         settings={settings}
         styles={styles}
@@ -184,14 +185,13 @@ const QSOList = React.memo(function QSOList ({ style, ourInfo, settings, qsos, s
     )
   }, [operation, settings, styles, onHeaderPress])
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- useCallback prefers to see an inline function
-  const calculateLayout = useCallback(
-    getItemLayout({
-      getItemHeight: styles.row.height + styles.row.borderBottomWidth,
-      getSectionHeaderHeight: styles.headerRow.height + styles.headerRow.borderBottomWidth
-    }),
-    [styles]
-  )
+  const hasMultipleSegments = useMemo(() => {
+    return hasMultipleSegmentsForQSOs(qsos)
+  }, [qsos])
+
+  const isStickyItem = useCallback(({ item }) => {
+    return hasMultipleSegments && isActiveSegmentEvent(item)
+  }, [hasMultipleSegments])
 
   const extractKey = useCallback((item, index) => item.uuid, [])
   const emptyComponent = useCallback(() => (
@@ -207,7 +207,7 @@ const QSOList = React.memo(function QSOList ({ style, ourInfo, settings, qsos, s
       sections={sections || []}
       renderItem={renderRow}
       renderSectionHeader={renderHeader}
-      getItemLayout={calculateLayout}
+      isStickyItem={isStickyItem}
       keyExtractor={extractKey}
       ListEmptyComponent={emptyComponent}
       keyboardShouldPersistTaps={'handled'} // Otherwise android closes the keyboard inbetween fields

--- a/src/screens/OperationScreens/OpLoggingTab/components/QSOListTools.js
+++ b/src/screens/OperationScreens/OpLoggingTab/components/QSOListTools.js
@@ -1,0 +1,12 @@
+// Copyright ©️ 2026 Robert Jackson <me@rwjblue.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export function hasMultipleSegmentsForQSOs (qsos) {
+  const activeSegmentEvents = (qsos ?? []).filter(isActiveSegmentEvent)
+
+  return activeSegmentEvents.length > 1
+}
+
+export function isActiveSegmentEvent (qso) {
+  return !qso?.deleted && qso?.band === 'event' && (qso.event?.event === 'start' || qso.event?.event === 'break')
+}

--- a/src/screens/OperationScreens/OpLoggingTab/components/QSOListTools.spec.js
+++ b/src/screens/OperationScreens/OpLoggingTab/components/QSOListTools.spec.js
@@ -1,0 +1,64 @@
+// Copyright ©️ 2026 Robert Jackson <me@rwjblue.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { hasMultipleSegmentsForQSOs, isActiveSegmentEvent } from './QSOListTools'
+
+function qso (uuid) {
+  return { uuid, band: '20m' }
+}
+
+function segmentEvent (uuid, event) {
+  return {
+    uuid,
+    band: 'event',
+    event: { event }
+  }
+}
+
+describe('QSOListTools', () => {
+  test('recognizes active segment events', () => {
+    expect([
+      isActiveSegmentEvent(segmentEvent('start', 'start')),
+      isActiveSegmentEvent(segmentEvent('break', 'break')),
+      isActiveSegmentEvent(segmentEvent('end', 'end')),
+      isActiveSegmentEvent({ ...segmentEvent('deleted-break', 'break'), deleted: true }),
+      isActiveSegmentEvent(qso('a'))
+    ]).toMatchInlineSnapshot(`
+      [
+        true,
+        true,
+        false,
+        false,
+        false,
+      ]
+    `)
+  })
+
+  test('keeps new and single-start operations in single-segment mode', () => {
+    expect([
+      hasMultipleSegmentsForQSOs([]),
+      hasMultipleSegmentsForQSOs([qso('a'), qso('b')]),
+      hasMultipleSegmentsForQSOs([segmentEvent('start', 'start'), qso('a')]),
+      hasMultipleSegmentsForQSOs([qso('a'), segmentEvent('break', 'break'), qso('b')])
+    ]).toMatchInlineSnapshot(`
+      [
+        false,
+        false,
+        false,
+        false,
+      ]
+    `)
+  })
+
+  test('promotes operations with multiple segment events to multi-segment mode', () => {
+    expect([
+      hasMultipleSegmentsForQSOs([segmentEvent('start', 'start'), qso('a'), segmentEvent('break', 'break'), qso('b')]),
+      hasMultipleSegmentsForQSOs([qso('a'), { ...segmentEvent('deleted-break', 'break'), deleted: true }])
+    ]).toMatchInlineSnapshot(`
+      [
+        true,
+        false,
+      ]
+    `)
+  })
+})

--- a/src/screens/OperationScreens/OpLoggingTab/components/entries/QSOHeader.jsx
+++ b/src/screens/OperationScreens/OpLoggingTab/components/entries/QSOHeader.jsx
@@ -8,10 +8,15 @@ import { Text } from 'react-native-paper'
 import { capitalizeFirstLetter, fmtNumber, fmtDateDynamicZulu } from '@ham2k/lib-format-tools'
 
 import { H2kIcon, H2kPressable } from '../../../../../ui'
+import { describeOperation } from '../../../../../store/operations'
 
-const QSOHeader = React.memo(function QSOHeader ({ section, operation, styles, settings, onHeaderPress }) {
+const QSOHeader = React.memo(function QSOHeader ({ section, contextItem, operation, styles, settings, onHeaderPress }) {
   // NOTE: We're using onPresOut instead of onPress because of a bug in SectionList
   // See https://github.com/facebook/react-native/issues/51290
+  const dateLabel = capitalizeFirstLetter(fmtDateDynamicZulu(section.day, { compact: true }))
+  const summary = contextItem?.event?.segmentSummary ?? section
+  const qsoCountLabel = qsoCountText(summary.count)
+  const segmentLabel = segmentHeaderLabel(contextItem?.event?.operation)
 
   return (
     <H2kPressable
@@ -19,30 +24,25 @@ const QSOHeader = React.memo(function QSOHeader ({ section, operation, styles, s
       style={styles.headerRow}
       accessible={true}
       accessibilityRole="header"
-      accessibilityLabel={`${capitalizeFirstLetter(fmtDateDynamicZulu(section.day, { compact: true }))} - ${fmtNumber(section.count ?? 0)} QSOs`}
+      accessibilityLabel={[dateLabel, segmentLabel, qsoCountLabel].filter(Boolean).join(' - ')}
     >
       <View style={styles.rowInner}>
         <Text style={[styles.fields.header, styles.text.bold, { minWidth: styles.oneSpace * 8 }]}>
-          {capitalizeFirstLetter(fmtDateDynamicZulu(section.day, { compact: true }))}
+          {dateLabel}
         </Text>
+        {segmentLabel ? (
+          <Text numberOfLines={1} ellipsizeMode={'tail'} style={[styles.fields.header, { flex: 1, marginRight: styles.oneSpace }]}>
+            {segmentLabel}
+          </Text>
+        ) : null}
         <Text style={[styles.fields.header, { flex: 0, textAlign: 'right', minWidth: styles.oneSpace * 8 }]}>
-          {
-            section.count === 0 ? (
-              'No QSOs'
-            ) : (
-              section.count === 1 ? (
-                '1 QSO'
-              ) : (
-                `${fmtNumber(section.count ?? 0)} QSOs`
-              )
-            )
-          }
+          {qsoCountLabel}
         </Text>
 
-        <Text style={[styles.fields.header, { flex: 1 }]}>{' '}</Text>
+        <Text style={[styles.fields.header, { flex: segmentLabel ? 0 : 1 }]}>{' '}</Text>
 
-        {Object.keys(section.scores ?? {}).sort((a, b) => (section.scores[a]?.weight ?? 0) - (section.scores[b]?.weight ?? 0)).map(key => {
-          const score = section.scores[key] ?? {}
+        {Object.keys(summary.scores ?? {}).sort((a, b) => (summary.scores[a]?.weight ?? 0) - (summary.scores[b]?.weight ?? 0)).map(key => {
+          const score = summary.scores[key] ?? {}
           const refKeys = Object.keys(score.refs ?? { one: true })
 
           if (score.summary && (score.icon || score.label)) {
@@ -69,4 +69,16 @@ const QSOHeader = React.memo(function QSOHeader ({ section, operation, styles, s
     </H2kPressable>
   )
 })
+
+function qsoCountText (count) {
+  if (count === 0) return 'No QSOs'
+  if (count === 1) return '1 QSO'
+  return `${fmtNumber(count ?? 0)} QSOs`
+}
+
+function segmentHeaderLabel (operation) {
+  const description = describeOperation({ operation })
+  return description.split(' • ')[0] || undefined
+}
+
 export default QSOHeader

--- a/src/screens/components/SectionFlashList.jsx
+++ b/src/screens/components/SectionFlashList.jsx
@@ -10,6 +10,8 @@
 import { FlashList } from '@shopify/flash-list'
 import React from 'react'
 
+import { buildSectionFlashListData } from './SectionFlashListTools'
+
 export function SectionFlashList ({
   sections, extraData, stickySectionHeadersEnabled,
   SectionSeparatorComponent,
@@ -19,37 +21,12 @@ export function SectionFlashList ({
   renderSectionHeader,
   renderSectionFooter,
   renderItem,
+  isStickyItem,
   overrideItemLayout,
   ...props
 }) {
-  const data = sections
-    .map((section) => {
-      return [
-        { type: 'sectionHeader', section, extraData },
-        ...section.data.map((item, index) => ({
-          type: 'row',
-          item,
-          index,
-          extraData
-        }))
-      ]
-    })
-    .flat()
+  const { data, stickyHeaderIndices } = buildSectionFlashListData({ sections, extraData, stickySectionHeadersEnabled, isStickyItem })
 
-  const stickyHeaderIndices = []
-  const sectionLabels = []
-
-  data.forEach((item, index) => {
-    if (item.type !== 'sectionHeader') {
-      return
-    }
-    sectionLabels.push({
-      actualIndex: index
-    })
-    if (stickySectionHeadersEnabled !== false) {
-      stickyHeaderIndices.push(index)
-    }
-  })
   const separator = (index, isSection) => {
     if (!data || index + 1 >= data.length) {
       return null
@@ -79,11 +56,26 @@ export function SectionFlashList ({
             : null}
           {renderSectionHeader?.({
             section: info.item.section,
+            contextItem: info.item.contextItem,
+            headerType: info.item.type,
+            target: info.target,
             extraData: info.extraData
           }) || null}
           {maintainVisibleContentPosition?.startRenderingFromBottom
             ? null
             : separator(info.index, true)}
+        </>
+      )
+    } else if (info.item.type === 'contextHeader') {
+      return (
+        <>
+          {renderSectionHeader?.({
+            section: info.item.section,
+            contextItem: info.item.contextItem,
+            headerType: info.item.type,
+            target: info.target,
+            extraData: info.extraData
+          }) || null}
         </>
       )
     } else if (info.item.type === 'sectionFooter') {
@@ -118,7 +110,7 @@ export function SectionFlashList ({
 
   const overrideItemLayoutWithSections = (layout, item, index, maxColumns, extra) => {
     overrideItemLayout?.(layout, item, index, maxColumns, extra)
-    if (item.type === 'sectionHeader') {
+    if (item.type === 'sectionHeader' || item.type === 'contextHeader') {
       layout.span = maxColumns
     } else {
       layout.span = 1
@@ -135,6 +127,7 @@ export function SectionFlashList ({
       stickyHeaderIndices={
         stickySectionHeadersEnabled !== false ? stickyHeaderIndices : []
       }
+      stickyHeaderConfig={{ hideRelatedCell: true, ...props.stickyHeaderConfig }}
       getItemType={(item) => item.type}
       maintainVisibleContentPosition={maintainVisibleContentPosition}
       horizontal={horizontal}

--- a/src/screens/components/SectionFlashList.spec.js
+++ b/src/screens/components/SectionFlashList.spec.js
@@ -1,0 +1,430 @@
+// Copyright ©️ 2026 Robert Jackson <me@rwjblue.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { buildSectionFlashListData } from './SectionFlashListTools'
+
+describe('buildSectionFlashListData', () => {
+  test('falls back to section data when no segment groups exist', () => {
+    const result = buildSectionFlashListData({
+      sections: [
+        {
+          day: 1000,
+          data: [{ uuid: 'a' }, { uuid: 'b' }]
+        }
+      ],
+      extraData: { selected: 'a' }
+    })
+
+    expect(summarizeFlashListData(result)).toMatchInlineSnapshot(`
+      {
+        "rows": [
+          {
+            "sectionDay": 1000,
+            "type": "sectionHeader",
+          },
+          {
+            "item": "a",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "item": "b",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+        ],
+        "stickyHeaderIndices": [
+          0,
+        ],
+      }
+    `)
+  })
+
+  test('promotes matching section rows to sticky context headers', () => {
+    const result = buildSectionFlashListData({
+      isStickyItem: ({ item }) => item.band === 'event' && (item.event?.event === 'start' || item.event?.event === 'break'),
+      sections: [
+        {
+          day: 1000,
+          data: [
+            { uuid: 'start', band: 'event', event: { event: 'start' } },
+            { uuid: 'a' },
+            { uuid: 'note', band: 'event', event: { event: 'note' } },
+            { uuid: 'break', band: 'event', event: { event: 'break' } },
+            { uuid: 'b' }
+          ]
+        }
+      ]
+    })
+
+    expect(summarizeFlashListData(result)).toMatchInlineSnapshot(`
+      {
+        "rows": [
+          {
+            "contextItem": "start",
+            "normal": "context",
+            "sectionDay": 1000,
+            "sticky": "section+context",
+            "type": "contextHeader",
+          },
+          {
+            "item": "start",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "item": "a",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "item": "note",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "contextItem": "break",
+            "normal": "context",
+            "sectionDay": 1000,
+            "sticky": "section+context",
+            "type": "contextHeader",
+          },
+          {
+            "item": "break",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "item": "b",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+        ],
+        "stickyHeaderIndices": [
+          0,
+          4,
+        ],
+      }
+    `)
+  })
+
+  test('carries active context into the next section', () => {
+    const result = buildSectionFlashListData({
+      isStickyItem: ({ item }) => item.band === 'event' && (item.event?.event === 'start' || item.event?.event === 'break'),
+      sections: [
+        {
+          day: 1000,
+          data: [
+            { uuid: 'start', band: 'event', event: { event: 'start' } },
+            { uuid: 'a' }
+          ]
+        },
+        {
+          day: 2000,
+          data: [
+            { uuid: 'b' }
+          ]
+        }
+      ]
+    })
+
+    expect(summarizeFlashListData(result)).toMatchInlineSnapshot(`
+      {
+        "rows": [
+          {
+            "contextItem": "start",
+            "normal": "context",
+            "sectionDay": 1000,
+            "sticky": "section+context",
+            "type": "contextHeader",
+          },
+          {
+            "item": "start",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "item": "a",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "contextItem": "start",
+            "normal": "section",
+            "sectionDay": 2000,
+            "sticky": "section+context",
+            "type": "sectionHeader",
+          },
+          {
+            "item": "b",
+            "sectionDay": 2000,
+            "type": "row",
+          },
+        ],
+        "stickyHeaderIndices": [
+          0,
+          3,
+        ],
+      }
+    `)
+  })
+
+  test('uses a new first-row context instead of carried section context', () => {
+    const result = buildSectionFlashListData({
+      isStickyItem: ({ item }) => item.band === 'event' && (item.event?.event === 'start' || item.event?.event === 'break'),
+      sections: [
+        {
+          day: 1000,
+          data: [
+            { uuid: 'start', band: 'event', event: { event: 'start' } },
+            { uuid: 'a' }
+          ]
+        },
+        {
+          day: 2000,
+          data: [
+            { uuid: 'break', band: 'event', event: { event: 'break' } },
+            { uuid: 'b' }
+          ]
+        }
+      ]
+    })
+
+    expect(summarizeFlashListData(result)).toMatchInlineSnapshot(`
+      {
+        "rows": [
+          {
+            "contextItem": "start",
+            "normal": "context",
+            "sectionDay": 1000,
+            "sticky": "section+context",
+            "type": "contextHeader",
+          },
+          {
+            "item": "start",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "item": "a",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "contextItem": "break",
+            "normal": "context",
+            "sectionDay": 2000,
+            "sticky": "section+context",
+            "type": "contextHeader",
+          },
+          {
+            "item": "break",
+            "sectionDay": 2000,
+            "type": "row",
+          },
+          {
+            "item": "b",
+            "sectionDay": 2000,
+            "type": "row",
+          },
+        ],
+        "stickyHeaderIndices": [
+          0,
+          3,
+        ],
+      }
+    `)
+  })
+
+  test('supports adding the first break after single-segment QSOs', () => {
+    const result = buildSectionFlashListData({
+      isStickyItem: ({ item }) => item.band === 'event' && item.event?.event === 'break',
+      sections: [
+        {
+          day: 1000,
+          data: [
+            { uuid: 'a' },
+            { uuid: 'break', band: 'event', event: { event: 'break' } },
+            { uuid: 'b' }
+          ]
+        }
+      ]
+    })
+
+    expect(summarizeFlashListData(result)).toMatchInlineSnapshot(`
+      {
+        "rows": [
+          {
+            "sectionDay": 1000,
+            "type": "sectionHeader",
+          },
+          {
+            "item": "a",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "contextItem": "break",
+            "normal": "context",
+            "sectionDay": 1000,
+            "sticky": "section+context",
+            "type": "contextHeader",
+          },
+          {
+            "item": "break",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "item": "b",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+        ],
+        "stickyHeaderIndices": [
+          0,
+          2,
+        ],
+      }
+    `)
+  })
+
+  test('omits context header rows with no local QSOs before the next section', () => {
+    const result = buildSectionFlashListData({
+      isStickyItem: ({ item }) => item.band === 'event' && (item.event?.event === 'start' || item.event?.event === 'break'),
+      sections: [
+        {
+          day: 1000,
+          data: [
+            { uuid: 'a' },
+            { uuid: 'break', band: 'event', event: { event: 'break' } }
+          ]
+        },
+        {
+          day: 2000,
+          data: [
+            { uuid: 'b' }
+          ]
+        }
+      ]
+    })
+
+    expect(summarizeFlashListData(result)).toMatchInlineSnapshot(`
+      {
+        "rows": [
+          {
+            "sectionDay": 1000,
+            "type": "sectionHeader",
+          },
+          {
+            "item": "a",
+            "sectionDay": 1000,
+            "type": "row",
+          },
+          {
+            "contextItem": "break",
+            "normal": "section",
+            "sectionDay": 2000,
+            "sticky": "section+context",
+            "type": "sectionHeader",
+          },
+          {
+            "item": "break",
+            "sectionDay": 2000,
+            "type": "row",
+          },
+          {
+            "item": "b",
+            "sectionDay": 2000,
+            "type": "row",
+          },
+        ],
+        "stickyHeaderIndices": [
+          0,
+          2,
+        ],
+      }
+    `)
+  })
+
+  test('omits first-row context headers when that day has no local QSOs', () => {
+    const result = buildSectionFlashListData({
+      isStickyItem: ({ item }) => item.band === 'event' && (item.event?.event === 'start' || item.event?.event === 'break'),
+      sections: [
+        {
+          day: 1000,
+          data: [
+            { uuid: 'break', band: 'event', event: { event: 'break' } }
+          ]
+        },
+        {
+          day: 2000,
+          data: [
+            { uuid: 'b' }
+          ]
+        }
+      ]
+    })
+
+    expect(summarizeFlashListData(result)).toMatchInlineSnapshot(`
+      {
+        "rows": [
+          {
+            "contextItem": "break",
+            "normal": "section",
+            "sectionDay": 2000,
+            "sticky": "section+context",
+            "type": "sectionHeader",
+          },
+          {
+            "item": "break",
+            "sectionDay": 2000,
+            "type": "row",
+          },
+          {
+            "item": "b",
+            "sectionDay": 2000,
+            "type": "row",
+          },
+        ],
+        "stickyHeaderIndices": [
+          0,
+        ],
+      }
+    `)
+  })
+
+  test('omits sticky indices when sticky section headers are disabled', () => {
+    const result = buildSectionFlashListData({
+      stickySectionHeadersEnabled: false,
+      sections: [
+        {
+          day: 1000,
+          data: [{ uuid: 'start', band: 'event', event: { event: 'start' } }]
+        }
+      ],
+      isStickyItem: ({ item }) => item.band === 'event'
+    })
+
+    expect(result.stickyHeaderIndices).toEqual([])
+  })
+})
+
+function summarizeFlashListData ({ data, stickyHeaderIndices }) {
+  return {
+    rows: data.map(row => compactObject({
+      type: row.type,
+      sectionDay: row.section?.day,
+      contextItem: row.contextItem?.uuid,
+      normal: row.type === 'contextHeader' ? 'context' : undefined,
+      ...(row.type === 'sectionHeader' && row.contextItem ? { normal: 'section' } : {}),
+      sticky: row.type === 'contextHeader' || (row.type === 'sectionHeader' && row.contextItem) ? 'section+context' : undefined,
+      item: row.item?.uuid
+    })),
+    stickyHeaderIndices
+  }
+}
+
+function compactObject (object) {
+  return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined))
+}

--- a/src/screens/components/SectionFlashListTools.js
+++ b/src/screens/components/SectionFlashListTools.js
@@ -1,0 +1,104 @@
+// Copyright ©️ 2026 Robert Jackson <me@rwjblue.com>
+// SPDX-License-Identifier: MPL-2.0
+
+export function buildSectionFlashListData ({ sections, extraData, stickySectionHeadersEnabled, isStickyItem }) {
+  let currentContextItem
+  let pendingContextDetailItem
+
+  const data = sections
+    .map((section) => {
+      const sectionRows = []
+      let sectionHeaderAdded = false
+      let sectionHasLocalRows = false
+
+      const addSectionHeader = () => {
+        if (sectionHeaderAdded) return
+        sectionRows.push({
+          type: 'sectionHeader',
+          section,
+          ...(currentContextItem ? { contextItem: currentContextItem } : {}),
+          extraData
+        })
+        sectionHeaderAdded = true
+        if (pendingContextDetailItem) {
+          sectionRows.push({
+            type: 'row',
+            item: pendingContextDetailItem.item,
+            index: pendingContextDetailItem.index,
+            section,
+            extraData
+          })
+          pendingContextDetailItem = undefined
+        }
+      }
+
+      section.data.forEach((item, index) => {
+        if (isStickyItem?.({ item, index, section, extraData }) === true) {
+          currentContextItem = item
+          pendingContextDetailItem = undefined
+          if (hasLocalRowsUntilNextStickyItem({ section, index, extraData, isStickyItem })) {
+            sectionRows.push({
+              type: 'contextHeader',
+              section,
+              contextItem: item,
+              index,
+              extraData
+            })
+            sectionHeaderAdded = true
+            sectionRows.push({
+              type: 'row',
+              item,
+              index,
+              section,
+              extraData
+            })
+          } else {
+            pendingContextDetailItem = { item, index }
+          }
+        } else {
+          sectionHasLocalRows = true
+          addSectionHeader()
+          sectionRows.push({
+            type: 'row',
+            item,
+            index,
+            section,
+            extraData
+          })
+        }
+      })
+      if (sectionHasLocalRows || !currentContextItem) {
+        addSectionHeader()
+      }
+
+      return sectionRows
+    })
+    .flat()
+
+  const stickyHeaderIndices = []
+
+  data.forEach((item, index) => {
+    if (item.type !== 'sectionHeader' && item.type !== 'contextHeader') {
+      return
+    }
+    if (stickySectionHeadersEnabled !== false) {
+      stickyHeaderIndices.push(index)
+    }
+  })
+
+  return { data, stickyHeaderIndices }
+}
+
+function hasLocalRowsUntilNextStickyItem ({ section, index, extraData, isStickyItem }) {
+  for (let nextIndex = index + 1; nextIndex < section.data.length; nextIndex++) {
+    const nextItem = section.data[nextIndex]
+    if (isStickyItem?.({ item: nextItem, index: nextIndex, section, extraData }) === true) {
+      return false
+    }
+    if (!nextItem?.deleted && !nextItem?.event) {
+      return true
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
**BLUF:** Adds sticky segment headers for multi-segment operation logs.

This keeps roving operation context visible while scrolling without using the abandoned two-row sticky overlay. For multi-segment operations, START and BREAK rows promote the gray date header into a segment-specific header with the activity reference and segment-local scoring summary, while the blue event row stays in the list for full location and grid detail.

The tricky case here is a BREAK immediately before a UTC day boundary with no intervening QSOs. That event is carried under the next day’s segment header so the list does not show a stranded blue break row above the date header.

Focused tests cover the section flattening behavior, multi-segment detection, and segment-local header scoring.

### Demos

<img width="374" height="800" alt="2026-06-14 at 12 54 48" src="https://github.com/user-attachments/assets/fd68bf7d-e2af-4c18-b205-04a122d5b3ed" />


