### PR TITLE
feat: add operation archive view

### DIFF
--- a/src/i18n/resources/en/polo.json
+++ b/src/i18n/resources/en/polo.json
@@ -24,7 +24,10 @@
       "noOperations": "No Operations!",
       "settings-a11y": "Settings",
       "quickCallLookupPlaceholder": "Quick Call Lookup…",
-      "spots-a11y": "Spots"
+      "spots-a11y": "Spots",
+      "archiveFolder": "Archive",
+      "archiveFolder-a11y": "Archive",
+      "archiveBack-a11y": "Back to operations"
     },
     "operation": {
       "title": "Operation"
@@ -113,7 +116,10 @@
         "title": "Delete operation?",
         "description": "Are you sure you want to delete this operation?"
       },
-      "errorSavingExport": "Couldn't save file"
+      "errorSavingExport": "Couldn't save file",
+      "operationManagement": "Operation Management",
+      "archived": "Archived",
+      "archivedDescription": "Show this operation in Archive"
     },
     "callInfo": {
       "title": "Callsign Info",

--- a/src/screens/HomeScreen/HomeScreen.jsx
+++ b/src/screens/HomeScreen/HomeScreen.jsx
@@ -1,17 +1,17 @@
 // Copyright ©️ 2024-2025 Sebastian Delmont <sd@ham2k.com>
 // SPDX-License-Identifier: MPL-2.0
 
-import React, { useCallback, useEffect, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { View } from 'react-native'
-import { AnimatedFAB, Text } from 'react-native-paper'
+import { AnimatedFAB, Icon, Text } from 'react-native-paper'
 import { useDispatch } from 'react-redux'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useTranslation } from 'react-i18next'
 
 import { useThemedStyles } from '../../styles/tools/useThemedStyles'
 import ScreenContainer from '../components/ScreenContainer'
-import { addNewOperation, selectOperationIds } from '../../store/operations'
+import { addNewOperation, selectOperationIdsByArchived } from '../../store/operations'
 import { selectSettings } from '../../store/settings'
 import OperationItem from './components/OperationItem'
 import HomeTools from './components/HomeTools'
@@ -19,6 +19,7 @@ import { trackEvent } from '../../distro'
 import { FlashList } from '@shopify/flash-list'
 import { useIsFocused } from '@react-navigation/native'
 import { useSelectorConditionally } from '../components/useConditionally'
+import { H2kPressable } from '../../ui'
 
 export default function HomeScreen ({ navigation }) {
   const { t } = useTranslation()
@@ -28,7 +29,9 @@ export default function HomeScreen ({ navigation }) {
   const styles = useThemedStyles(prepareStyles, { safeArea })
 
   const isFocused = useIsFocused()
-  const operationIds = useSelectorConditionally(isFocused, selectOperationIds)
+  const [showArchive, setShowArchive] = useState(false)
+  const operationIds = useSelectorConditionally(isFocused, (state) => selectOperationIdsByArchived(state, showArchive))
+  const archivedOperationIds = useSelectorConditionally(isFocused, (state) => selectOperationIdsByArchived(state, true))
   const settings = useSelectorConditionally(isFocused, selectSettings)
 
   useEffect(() => {
@@ -53,7 +56,26 @@ export default function HomeScreen ({ navigation }) {
     navigation.navigate('Operation', { uuid: operation.uuid, operation })
   }, [navigation])
 
+  const navigateToArchive = useCallback(() => {
+    setShowArchive(true)
+  }, [])
+
+  const navigateOutOfArchive = useCallback(() => {
+    setShowArchive(false)
+  }, [])
+
   const renderRow = useCallback(({ item }) => {
+    if (item === '__archive__') {
+      return (
+        <ArchiveItem
+          count={archivedOperationIds?.length ?? 0}
+          styles={styles}
+          style={{ paddingLeft: safeArea.left, paddingRight: safeArea.right }}
+          onPress={navigateToArchive}
+        />
+      )
+    }
+
     return (
       <OperationItem
         key={item}
@@ -64,7 +86,12 @@ export default function HomeScreen ({ navigation }) {
         onPress={navigateToOperation}
       />
     )
-  }, [navigateToOperation, styles, settings, safeArea])
+  }, [archivedOperationIds?.length, navigateToArchive, navigateToOperation, styles, settings, safeArea])
+
+  const listData = useMemo(() => {
+    if (showArchive) return operationIds
+    return [...(operationIds || []), '__archive__']
+  }, [operationIds, showArchive])
 
   const [isExtended, setIsExtended] = React.useState(true)
 
@@ -82,25 +109,80 @@ export default function HomeScreen ({ navigation }) {
         <FlashList
           accesibilityLabel={t('screens.home.operationList-a11y', 'screens.home.operationList', 'Operation List')}
           style={styles.list}
-          data={operationIds}
+          data={listData}
           renderItem={renderRow}
+          ListHeaderComponent={showArchive ? <ArchiveHeader styles={styles} onBack={navigateOutOfArchive} /> : null}
           ListEmptyComponent={emptyListComponent}
           keyboardShouldPersistTaps={'handled'}
           onScroll={handleScroll}
         />
-        <AnimatedFAB
-          icon="plus"
-          label={t('screens.home.newOperation', 'New Operation')}
-          accessibilityLabel={t('screens.home.newOperation-a11y', 'screens.home.newOperation', 'New Operation')}
-          mode="elevated"
-          extended={isExtended}
-          style={styles.fab}
-          onPress={handleNewOperation}
-        />
+        {!showArchive && (
+          <AnimatedFAB
+            icon="plus"
+            label={t('screens.home.newOperation', 'New Operation')}
+            accessibilityLabel={t('screens.home.newOperation-a11y', 'screens.home.newOperation', 'New Operation')}
+            mode="elevated"
+            extended={isExtended}
+            style={styles.fab}
+            onPress={handleNewOperation}
+          />
+        )}
       </View>
 
       <HomeTools settings={settings} styles={styles} />
     </ScreenContainer>
+  )
+}
+
+function ArchiveItem ({ count, styles, style, onPress }) {
+  const { t } = useTranslation()
+  const archiveLabel = t('screens.home.archiveFolder', 'Archive').toUpperCase()
+  const rowStyle = {
+    ...styles.row,
+    paddingHorizontal: 0,
+    paddingLeft: Math.max(styles?.row?.paddingHorizontal, style?.paddingLeft ?? 0),
+    paddingRight: Math.max(styles.row.paddingHorizontal, style?.paddingRight ?? 0)
+  }
+
+  return (
+    <H2kPressable
+      onPress={onPress}
+      accessibilityLabel={t('screens.home.archiveFolder-a11y', 'Archive')}
+      style={styles.rowRoot}
+    >
+      <View style={rowStyle}>
+        <View style={styles.rowTop}>
+          <View style={[styles.rowTopLeft, styles.archiveLabelRow]}>
+            <Text style={[styles.rowText, { fontWeight: 'bold' }]}>{archiveLabel}</Text>
+            <Icon source="archive-outline" size={styles.normalFontSize * 1.3} />
+          </View>
+          <View style={styles.rowTopRight}>
+            <View style={styles.countContainer}>
+              <Text style={styles.countText}>{count}</Text>
+            </View>
+          </View>
+        </View>
+      </View>
+    </H2kPressable>
+  )
+}
+
+function ArchiveHeader ({ styles, onBack }) {
+  const { t } = useTranslation()
+  const archiveLabel = t('screens.home.archiveFolder', 'Archive').toUpperCase()
+
+  return (
+    <H2kPressable onPress={onBack} accessibilityLabel={t('screens.home.archiveBack-a11y', 'Back to operations')} style={styles.rowRoot}>
+      <View style={[styles.row, { paddingHorizontal: styles.row.paddingHorizontal }]}>
+        <View style={[styles.rowTop, { alignItems: 'center' }]}>
+          <View style={[styles.rowTopLeft, styles.archiveLabelRow]}>
+            <Text style={styles.rowText}>{'←'}</Text>
+            <Icon source="archive-outline" size={styles.normalFontSize * 1.3} />
+            <Text style={[styles.rowText, { fontWeight: 'bold' }]}>{archiveLabel}</Text>
+          </View>
+        </View>
+      </View>
+    </H2kPressable>
   )
 }
 
@@ -145,6 +227,11 @@ function prepareStyles (baseStyles, { safeArea }) {
     rowTop: {
       flexDirection: 'row',
       justifyContent: 'space-between',
+      gap: baseStyles.oneSpace
+    },
+    archiveLabelRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
       gap: baseStyles.oneSpace
     },
     rowBottom: {

--- a/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
+++ b/src/screens/OperationScreens/OpSettingsTab/OperationDataScreen.jsx
@@ -15,7 +15,7 @@ import { parseCallsign } from '@ham2k/lib-callsigns'
 import { annotateFromCountryFile } from '@ham2k/lib-country-files'
 import { DXCC_BY_PREFIX } from '@ham2k/lib-dxcc-data'
 
-import { dataExportOptions, generateExportsForOptions, importADIFIntoOperation, loadOperation, selectOperation, selectOperationCallInfo } from '../../../store/operations'
+import { dataExportOptions, generateExportsForOptions, importADIFIntoOperation, loadOperation, selectOperation, selectOperationCallInfo, setOperationLocalData } from '../../../store/operations'
 import { loadQSOs, selectQSOs } from '../../../store/qsos'
 import { selectSettings, setSettings } from '../../../store/settings'
 import { useThemedStyles } from '../../../styles/tools/useThemedStyles'
@@ -235,10 +235,32 @@ export default function OperationDataScreen (props) {
     })
   }, [navigation, operation.uuid, pendingTodos])
 
+  const handleArchivedToggle = useCallback(() => {
+    dispatch(setOperationLocalData({ uuid: operation.uuid, archived: !operation?.local?.archived }))
+  }, [dispatch, operation?.local?.archived, operation.uuid])
+
   return (
     <ScreenContainer>
       <SafeAreaView edges={['left', 'right', 'bottom']} style={{ flex: 1 }}>
         <ScrollView style={{ flex: 1 }}>
+          <H2kListSection title={t('screens.operationData.operationManagement', 'Operation Management')}>
+            <View style={{ flexDirection: 'row', width: '100%', marginLeft: styles.oneSpace * 1, alignItems: 'flex-start' }}>
+              <View style={{ marginTop: styles.oneSpace * 1, marginRight: styles.oneSpace * -1.5 }}>
+                <Checkbox
+                  status={operation?.local?.archived ? 'checked' : 'unchecked'}
+                  onPress={handleArchivedToggle}
+                />
+              </View>
+              <H2kListItem
+                title={t('screens.operationData.archived', 'Archived')}
+                description={t('screens.operationData.archivedDescription', 'Show this operation in Archive')}
+                leftIcon="archive-outline"
+                onPress={handleArchivedToggle}
+                style={{ flex: 1 }}
+              />
+            </View>
+          </H2kListSection>
+
           <H2kListSection title={t('screens.operationData.exportQSOs', 'Export QSOs')}>
 
             {pendingTodos.length > 0 && (

--- a/src/store/operations/operationsSlice.js
+++ b/src/store/operations/operationsSlice.js
@@ -133,6 +133,26 @@ export const selectOperationIds = createSelector(
   }
 )
 
+export const selectOperationIdsByArchived = createSelector(
+  (state) => state?.operations?.info,
+  (state) => state?.settings?.showDeletedOps,
+  (state, archived) => archived,
+  (info, showDeletedOps, archived) => {
+    return Object.values(info || {})
+      .filter(op => op?.uuid && (showDeletedOps || !op?.deleted) && Boolean(op?.local?.archived) === Boolean(archived))
+      .sort(_operationSorter)
+      .map(op => op.uuid)
+  },
+  {
+    memoizeOptions: {
+      resultEqualityCheck: (prevIds, nextIds) => {
+        if (prevIds.length !== nextIds.length) return false
+        return prevIds.every((id, index) => id === nextIds[index])
+      }
+    }
+  }
+)
+
 export const selectOperationCallInfo = createSelector(
   (state, uuid) => selectOperationCall(state, uuid),
   (state) => selectOperatorCall(state),


### PR DESCRIPTION
## Summary

Adds a lightweight archive workflow for operations.

- Adds an Archive row on the Home screen showing the count of archived operations
- Adds an Archive view listing archived operations separately from the active operation list
- Adds an Archived checkbox in Operation Data
- Adds an archived-operation selector in the operations store
- Adds minimal English i18n keys for the new UI

## Scope

This PR intentionally excludes local Android/package changes from the earlier branch.

Not included:

- Android Gradle/build changes
- package rename changes
- app name changes
- APK/release/Hermes/ABI changes
- Crowdin/generated translation updates

## Testing

- Validated modified JSON
- `npm test -- --runInBand` passed: 5 suites, 43 tests
- `npx eslint` passed on changed JS/JSX files

Notes:

- Full `npm run lint` is currently blocked by an unrelated existing lint error in `CWKeyControl.jsx`
- `./gradlew test` could not run locally because no Java Runtime is installed/visible