### PR TITLE
Deep links for companion apps: /operation, /vfo, and /qso routes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,10 @@ In-app translation testing:
 
 ## Deep Linking
 
-To test deep linking, you can use the following commands:
+To test deep linking, you can use the following commands. The command is the URL
+*path*, so use three slashes (`com.ham2k:///qso?...`); the host is reserved. Any
+reserved character in a value (e.g. the `/` in a SOTA ref or a portable callsign)
+must be percent-encoded.
 ```
 export POLO_URL="com.ham2k:///qso?their.call=W1WC&mode=CW&freq=7200"
 

--- a/ios/polo/AppDelegate.swift
+++ b/ios/polo/AppDelegate.swift
@@ -35,7 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, RNAppAuthAuthorizationFlo
     return true
   }
 
-  // "open url" delegate function, for deeplinks like com.ham2k.polo://qso?... or com.ham2k.polo.auth://sota (using react-native-app-auth)
+  // "open url" delegate function, for deeplinks like com.ham2k.polo:///qso?... (command in the path; host reserved) or com.ham2k.polo.auth://sota (using react-native-app-auth)
   public weak var authorizationFlowManagerDelegate: RNAppAuthAuthorizationFlowManagerDelegate?
   func application(
     _ application: UIApplication,

--- a/src/DeepLinks.jsx
+++ b/src/DeepLinks.jsx
@@ -10,27 +10,63 @@
  * or the longer one if you want only PoLo to handle the link.
  * The examples below use the shorter schema for brevity.
  *
+ * The command is the URL *path*, so use three slashes (`com.ham2k:///qso?...`);
+ * the host is reserved for other purposes and a host-form link is ignored.
+ * Any value containing reserved characters must be percent-encoded - this
+ * includes the `/` in a SOTA reference (`W6/CT-006` -> `W6%2FCT-006`) and in a
+ * portable callsign (`S5/KC6X/P` -> `S5%2FKC6X%2FP`).
+ *
+ * # Set up an operation:
+ *
+ *   `com.ham2k:///operation?our.refs=pota:US-1234,sota:W6%2FCT-006`
+ *
+ *   - `our.refs`: References for our own activation, a comma separated list of
+ *      type:ref pairs. Finds a recent operation activating exactly those
+ *      references, or creates one, and opens it for logging.
+ *
+ * # Set the logging frequency and mode:
+ *
+ *   `com.ham2k:///vfo?frequency=14250000&mode=SSB`
+ *
+ *   - `frequency`: Frequency in Hz
+ *   - `freq`: Frequency in kHz (used only if `frequency` is absent)
+ *   - `mode`: Mode (optional; derived from the frequency if omitted)
+ *
+ *   Applies to the operation currently open (or the most recent one), so
+ *   contacts logged from then on use the new frequency and mode. Useful for
+ *   companion apps (SOTAcat, SOTAmat) that already handle spotting themselves
+ *   and only need PoLo's log to follow the radio.
+ *
  * # Present a QSO for logging:
  *
- *   `com.ham2k://qso?their.call=N0CALL&frequency=7200000&mode=CW`
+ *   `com.ham2k:///qso?their.call=N0CALL&frequency=7200000&mode=CW`
  *
- *   - `their.call`: The callsign of the other station
+ *   - `their.call`: The callsign of the other station. May be a comma-separated
+ *      list for multi-operator activations (e.g. `their.call=KI2D,KC6X`).
  *   - `frequency`: Frequency of the QSO in Hz
- *   - `freq`: Frequency of the QSO in kHz
+ *   - `freq`: Frequency of the QSO in kHz (used only if `frequency` is absent)
  *   - `band`: Band for the QSO (if `frequency` or `freq` is provided, this is ignored)
+ *   - `mode`: Mode of the QSO (optional; derived from the frequency if omitted)
  *   - `startAtMillis`: Timestamp of the QSO in milliseconds since epoch (optional)
- *   - `mode`: Mode of the QSO
- *   - `their.refs` (or `refs`): References for the other station, comma separated list of type:ref pairs (i.e. "POTA:US-1234,POTA:US-4567,SOTA:W6/CT-225")
+ *   - `their.refs`: References for the station being worked, a comma separated
+ *      list of type:ref pairs (i.e. "pota:US-1234,sota:W6%2FCT-225").
+ *      These become the hunted references on the suggested QSO.
+ *   - `returnpath`: Origin of the calling app (reserved; currently ignored).
+ *
+ *   The QSO is presented in the operation currently open, or the most recent
+ *   one. Reference types are matched against the activity registry; unknown
+ *   types are skipped.
  *
  * # Link a Client
- *   `com.ham2k://link_client?id=1234&token=ABC...`
+ *   `com.ham2k:///link_client?id=1234&token=ABC...`
  */
 
 import { useCallback, useEffect, useRef } from 'react'
 import { Linking } from 'react-native'
 import { useDispatch } from 'react-redux'
-import { selectLatestOperation } from './store/operations'
-import { bandForFrequency } from '@ham2k/lib-operation-data'
+
+import { selectLatestOperation, findOrCreateOperation } from './store/operations'
+import { buildSuggestedQSO, parseRefs } from './tools/deepLinkTools'
 
 const DEBUG = false
 
@@ -58,47 +94,48 @@ export function DeepLinks ({ navigationRef }) {
       console.log('-- params:', params)
     }
 
-    if (path === '/qso') {
-      let freq
-      if (params.freq) {
-        freq = Number(params.freq)
-      } else if (params.frequency) {
-        freq = Number(params.frequency) / 1000
-      }
-      const band = freq ? bandForFrequency(freq) : params.band
+    if (path === '/operation') {
+      const ourRefs = parseRefs(params['our.refs'])
+      if (DEBUG) console.log('🔗 Deep Link to Operation:', ourRefs)
+      if (!ourRefs?.length) return
 
-      const qso = {
-        uuid: 'suggested-qso',
-        their: { call: params['their.call'] },
-        band,
-        freq,
-        mode: params.mode?.toUpperCase(),
-        startAtMillis: params.startAtMillis ? Number(params.startAtMillis) : undefined,
-        _suggestedKey: url
-      }
-
-      if (params['their.refs']) {
-        qso.refs = _parseRefs(params['their.refs'] || params.refs)
-      }
+      _onceNavigationIsReady(navigationRef, () => {
+        dispatch(async (thunkDispatch) => {
+          const operation = await thunkDispatch(findOrCreateOperation({ ourRefs }))
+          navigationRef.current.navigate('Operation', { uuid: operation.uuid, operation, screen: 'OpLog' })
+        })
+      })
+    } else if (path === '/qso' || path === '/vfo') {
+      // `/vfo` only carries a frequency and mode; `/qso` also suggests the
+      // station being worked. Both are presented in the current operation,
+      // where the suggested QSO's freq/mode become the new VFO.
+      const qsoParams = path === '/vfo'
+        ? { frequency: params.frequency, freq: params.freq, mode: params.mode }
+        : params
+      const qso = buildSuggestedQSO(qsoParams, url)
 
       if (DEBUG) console.log('🔗 Deep Link to QSO:', { ...qso, their: { ...qso?.their || {} } })
 
-      _onceNavigationIsReady(navigationRef, async () => {
-        console.log('-- navigationRef.current', navigationRef.current?.getRootState())
+      _onceNavigationIsReady(navigationRef, () => {
+        if (DEBUG) console.log('-- navigationRef.current', navigationRef.current?.getRootState())
         const navState = navigationRef.current.getRootState()
         const route = navState.routes[navState.index]
-        console.log('-- current route', route)
+        if (DEBUG) console.log('-- current route', route?.name)
+
+        // Use `screen: 'OpLog'` below to force navigation to the logging tab, where the prefilled QSO appears.
         if (route?.name === 'Operation' || route?.name === 'OpLog') {
-          const navParams = { qso }
+          // present the QSO in the operation currently open
+          const navParams = { qso, screen: 'OpLog' }
           if (route.params.operation) navParams.operation = route.params.operation
           if (route.params.uuid) navParams.uuid = route.params.uuid
-          console.log('-- existing route, navigating to', route?.name, navParams)
-          navigationRef.current.navigate(route?.name, navParams)
+          navigationRef.current.navigate('Operation', navParams)
         } else {
-          console.log('-- no existing route, navigating to Operation')
-          await dispatch((_dispatch, getState) => {
+          // no operation open: fall back to the most recent operation
+          if (DEBUG) console.log('-- no existing route, navigating to Operation')
+          dispatch((_dispatch, getState) => {
             const operation = selectLatestOperation(getState())
-            navigationRef.current.navigate('Operation', { qso, uuid: operation.uuid })
+            if (!operation) return
+            navigationRef.current.navigate('Operation', { qso, uuid: operation.uuid, screen: 'OpLog' })
           })
         }
       })
@@ -132,32 +169,20 @@ export function DeepLinks ({ navigationRef }) {
   return null // This is a headless component
 }
 
-function _parseRefs (refsString) {
-  const refs = []
-  const parts = refsString.split(',').map(r => r.trim()).filter(r => r)
-  parts.forEach(part => {
-    const [type, ref] = part.split(':')
-    if (type && ref) {
-      refs.push({ type: type.toLowerCase(), ref })
-    }
-  })
-  return refs
-}
-
 function _onceNavigationIsReady (navigationRef, callback) {
-  console.log('Navigation is ready', navigationRef.current?.isReady())
+  if (DEBUG) console.log('Navigation is ready', navigationRef.current?.isReady())
   if (navigationRef.current?.isReady()) {
-    console.log('Navigation is ready')
+    if (DEBUG) console.log('Navigation is ready')
     callback()
   } else {
     let tries = 0
     const maxTries = 20 // 20 * 100ms = 2000ms = 2s
     const tryCallback = () => {
       if (navigationRef.current?.isReady()) {
-        console.log('Navigation is ready, calling callback')
+        if (DEBUG) console.log('Navigation is ready, calling callback')
         callback()
       } else if (tries < maxTries) {
-        console.log('Navigation is not ready, trying again', tries)
+        if (DEBUG) console.log('Navigation is not ready, trying again', tries)
         tries++
         setTimeout(tryCallback, 100)
       }

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/loggingFunctions.js
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/loggingFunctions.js
@@ -6,6 +6,7 @@ import cloneDeep from 'clone-deep'
 import UUID from 'react-native-uuid'
 
 import { findHooks } from '../../../../../extensions/registry'
+import { setVFO } from '../../../../../store/station/stationSlice'
 import { selectStateForComponentAndKey, setStateForComponentAndKey } from '../../../../../store/ui'
 import { resetCallLookupCache } from './useCallLookup'
 
@@ -67,6 +68,13 @@ export function prepareSuggestedQSO (qso, qsos, operation, vfo, settings) {
   return clone
 }
 
+// A brand-new QSO with no callsign entered is just the blank starting point
+// seeded from the VFO; only preserve an interrupted entry the operator actually
+// began, otherwise restoring it later would revert freq/mode to stale values.
+function qsoWorthQueuing (qso) {
+  return qso?._isNew && !qso?._isSuggested && !!qso?.their?.call
+}
+
 export const manageNextQSO = ({ selectedUUID, suggestedQSO, qsos, operation, vfo, settings }) => (dispatch, getState) => {
   qsos = qsos || []
 
@@ -84,7 +92,15 @@ export const manageNextQSO = ({ selectedUUID, suggestedQSO, qsos, operation, vfo
   let nextQSO
   if (suggestedQSO) {
     nextQSO = prepareSuggestedQSO(suggestedQSO, qsos, operation, vfo, settings)
-    if (qso?._isNew && !qso?._isSuggested) {
+    // A suggested QSO, from a deep link or from tapping a spot, carries an
+    // authoritative freq/mode. Record it as the VFO so subsequent new QSOs
+    // (which are seeded from the VFO) start from it.
+    const vfoUpdate = {}
+    if (nextQSO.freq) vfoUpdate.freq = nextQSO.freq
+    if (nextQSO.band) vfoUpdate.band = nextQSO.band
+    if (nextQSO.mode) vfoUpdate.mode = nextQSO.mode
+    if (Object.keys(vfoUpdate).length) dispatch(setVFO(vfoUpdate))
+    if (qsoWorthQueuing(qso)) {
       dispatch(setStateForComponentAndKey({
         component: 'OpLoggingTab',
         key: 'qsoQueue',
@@ -99,7 +115,7 @@ export const manageNextQSO = ({ selectedUUID, suggestedQSO, qsos, operation, vfo
     } else {
       nextQSO = prepareNewQSO(operation, qsos, vfo, settings)
     }
-    if (qso?._isNew && !qso?._isSuggested) {
+    if (qsoWorthQueuing(qso)) {
       dispatch(setStateForComponentAndKey({
         component: 'OpLoggingTab',
         key: 'qsoQueue',

--- a/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/loggingFunctions.spec.js
+++ b/src/screens/OperationScreens/OpLoggingTab/components/LoggingPanel/loggingFunctions.spec.js
@@ -1,0 +1,191 @@
+// Copyright ©️ 2026 Jeff Kowalski <jeff.kowalski@gmail.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// A deep-linked suggested QSO carries an authoritative freq/mode. These tests
+// cover how it interacts with the logging flow: the freq/mode must become the
+// VFO ("last known good") so the next QSO keeps them after logging, an
+// unstarted blank QSO must not be queued and restored (which would revert the
+// freq/mode), and an interrupted manual entry must be preserved.
+
+import { manageNextQSO } from './loggingFunctions'
+import { buildSuggestedQSO } from '../../../../../tools/deepLinkTools'
+import { setVFO } from '../../../../../store/station/stationSlice'
+import { bandForFrequency } from '@ham2k/lib-operation-data'
+
+jest.mock('@ham2k/lib-operation-data', () => ({
+  bandForFrequency: (freq) => {
+    if (freq >= 14000 && freq < 14350) return '20m'
+    if (freq >= 7000 && freq < 7300) return '40m'
+    return undefined
+  },
+  modeForFrequency: (freq) => (freq < 10000 ? 'CW' : 'SSB')
+}))
+
+jest.mock('../../../../../extensions/registry', () => ({
+  findHooks: (category, { key } = {}) => {
+    if (category !== 'activity') return []
+    // Activities carry no `prepareNewQSO`, so the QSO-prep hooks are inert here.
+    const hooks = [
+      { key: 'sota', activationType: 'sotaActivation', huntingType: 'sota' },
+      { key: 'pota', activationType: 'potaActivation', huntingType: 'pota' }
+    ]
+    return key ? hooks.filter(h => h.key === key) : hooks
+  }
+}))
+
+// Back the UI-state helpers with the real (state.ui[component][key]) shape so
+// manageNextQSO can read/write the in-progress QSO through our harness store.
+jest.mock('../../../../../store/ui', () => ({
+  setStateForComponentAndKey: (payload) => ({ type: 'ui/setStateForComponentAndKey', payload }),
+  selectStateForComponentAndKey: (state, component, key) => state?.ui?.[component]?.[key]
+}))
+
+jest.mock('./useCallLookup', () => ({ resetCallLookupCache: () => () => {} }))
+
+// Stub the station slice so importing loggingFunctions doesn't pull in
+// @reduxjs/toolkit (ESM, untransformed by the RN jest preset). The harness below
+// applies the resulting setVFO action, mirroring the real reducer (merge freq/mode,
+// recompute band from freq).
+jest.mock('../../../../../store/station/stationSlice', () => ({
+  setVFO: (payload) => ({ type: 'station/setVFO', payload })
+}))
+
+// --- harness: a minimal store that applies the only two action kinds these paths
+// dispatch (UI-state writes and VFO writes), so VFO round-trips like production.
+function makeHarness (initialVFO) {
+  const state = { ui: {}, vfo: { ...initialVFO } }
+  const getState = () => state
+  const dispatch = (action) => {
+    if (typeof action === 'function') return action(dispatch, getState)
+    if (action?.type === 'ui/setStateForComponentAndKey') {
+      const { component, key, value } = action.payload
+      state.ui[component] = state.ui[component] || {}
+      state.ui[component][key] = value
+    } else if (action?.type === 'station/setVFO') {
+      const data = { ...action.payload }
+      if (data.freq) data.band = bandForFrequency(data.freq)
+      state.vfo = { ...state.vfo, ...data }
+    }
+    return action
+  }
+  return {
+    dispatch,
+    getState,
+    vfo: () => state.vfo,
+    currentQSO: () => state.ui.OpLoggingTab?.qso
+  }
+}
+
+const OPERATION = { uuid: 'op-1', local: {} }
+
+const URL_VFO = 'com.ham2k:///vfo?frequency=14285000&mode=SSB'
+const URL_QSO = 'com.ham2k:///qso?their.call=K1ABC&their.refs=pota%3AUS-1234&frequency=7185000&mode=CW'
+
+// Parse the URL the way DeepLinks.jsx does (inline `new URL` on the path),
+// then build the suggested QSO from the resulting params.
+function suggestedFromURL (url) {
+  const [, rest] = url.split('://')
+  const [hostname, ...restParts] = rest.split('/')
+  const urlObject = new URL(`https://${hostname || 'default:1'}/${restParts.join('/')}`)
+  const params = Object.fromEntries(urlObject.searchParams)
+  return buildSuggestedQSO(params, url)
+}
+
+// Models the user logging the in-progress QSO: clear the form, then ask for the
+// next QSO from the current VFO, exactly what LoggingPanel does after addQSOs().
+function logCurrentAndAdvance (h) {
+  const logged = h.currentQSO()
+  h.dispatch({ type: 'ui/setStateForComponentAndKey', payload: { component: 'OpLoggingTab', key: 'qso', value: undefined } })
+  h.dispatch(manageNextQSO({ qsos: [logged], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+  return h.currentQSO()
+}
+
+// Mirror the app's steady state right after logging a contact: a blank new QSO
+// is already showing, seeded from the current VFO. This blank is what a
+// suggested QSO interrupts, and what must not be queued and restored.
+function seedBlankQSO (h) {
+  h.dispatch(manageNextQSO({ qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+}
+
+describe('deep-linked frequency and mode (vfo link)', () => {
+  it('applies the freq/mode to the in-progress QSO', () => {
+    const h = makeHarness({ band: '40m', freq: 7000, mode: 'SSB' })
+    h.dispatch(manageNextQSO({ suggestedQSO: suggestedFromURL(URL_VFO), qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+
+    const qso = h.currentQSO()
+    expect(qso.freq).toBe(14285) // 14285000 Hz / 1000
+    expect(qso.mode).toBe('SSB')
+    expect(qso.band).toBe('20m')
+  })
+
+  it('updates the VFO to the suggested freq/mode', () => {
+    const h = makeHarness({ band: '40m', freq: 7000, mode: 'SSB' })
+    h.dispatch(manageNextQSO({ suggestedQSO: suggestedFromURL(URL_VFO), qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+
+    expect(h.vfo().freq).toBe(14285)
+    expect(h.vfo().mode).toBe('SSB')
+  })
+
+  it('keeps the next QSO on the most recent freq/mode after logging', () => {
+    const h = makeHarness({ band: '40m', freq: 7000, mode: 'SSB' })
+    seedBlankQSO(h) // operator is sitting on a blank QSO at 7000 when the link arrives
+    h.dispatch(manageNextQSO({ suggestedQSO: suggestedFromURL(URL_VFO), qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+
+    const next = logCurrentAndAdvance(h)
+    expect(next.freq).toBe(14285)
+    expect(next.mode).toBe('SSB')
+    expect(next.band).toBe('20m')
+  })
+
+  it('carries the VFO forward to a new QSO when the VFO has been written', () => {
+    // control: when the VFO IS written (as a manual freq edit does),
+    // carry-forward works, isolating the VFO write as the load-bearing step
+    const h = makeHarness({ band: '40m', freq: 7000, mode: 'SSB' })
+    h.dispatch(setVFO({ freq: 14285, mode: 'SSB' })) // what editing the freq field dispatches
+
+    h.dispatch(manageNextQSO({ qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+    const qso = h.currentQSO()
+    expect(qso.freq).toBe(14285)
+    expect(qso.mode).toBe('SSB')
+    expect(qso.band).toBe('20m')
+  })
+
+  it('preserves an interrupted entry (with a call) across a deep link', () => {
+    // if the operator had already started a contact, that entry must be
+    // restored after the deep-linked QSO is logged; only empty blanks are dropped
+    const h = makeHarness({ band: '40m', freq: 7000, mode: 'SSB' })
+    seedBlankQSO(h)
+    const started = { ...h.currentQSO(), their: { call: 'N0CALL' } } // operator typed a call
+    h.dispatch({ type: 'ui/setStateForComponentAndKey', payload: { component: 'OpLoggingTab', key: 'qso', value: started } })
+
+    h.dispatch(manageNextQSO({ suggestedQSO: suggestedFromURL(URL_VFO), qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+
+    const next = logCurrentAndAdvance(h)
+    expect(next.their?.call).toBe('N0CALL')
+    expect(next.freq).toBe(7000)
+  })
+})
+
+describe('deep-linked suggested QSO (qso link)', () => {
+  it('applies the freq/mode and their.call to the in-progress QSO', () => {
+    const h = makeHarness({ band: '20m', freq: 14250, mode: 'SSB' })
+    h.dispatch(manageNextQSO({ suggestedQSO: suggestedFromURL(URL_QSO), qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+
+    const qso = h.currentQSO()
+    expect(qso.freq).toBe(7185) // 7185000 Hz / 1000
+    expect(qso.mode).toBe('CW')
+    expect(qso.their.call).toBe('K1ABC')
+  })
+
+  it('keeps the next QSO on the suggested freq/mode after logging, without the call', () => {
+    const h = makeHarness({ band: '20m', freq: 14250, mode: 'SSB' })
+    seedBlankQSO(h) // blank QSO at 14250 showing before the link
+    h.dispatch(manageNextQSO({ suggestedQSO: suggestedFromURL(URL_QSO), qsos: [], operation: OPERATION, vfo: h.vfo(), settings: {} }))
+
+    const next = logCurrentAndAdvance(h)
+    expect(next.freq).toBe(7185)
+    expect(next.mode).toBe('CW')
+    expect(next.band).toBe('40m')
+    expect(next.their?.call).toBeUndefined()
+  })
+})

--- a/src/screens/OperationScreens/OperationScreen.jsx
+++ b/src/screens/OperationScreens/OperationScreen.jsx
@@ -68,12 +68,17 @@ export default function OperationScreen(props) {
     if (route?.params?.qso && lastSuggestedQSO !== route?.params?.qso) {
       setLastSuggestedQSO(route?.params?.qso)
       dispatch(manageNextQSO({ suggestedQSO: route?.params?.qso, qsos, operation, settings }))
+      // Clear the consumed suggestion from the route params so it cannot be
+      // re-injected if this screen later remounts (e.g. when the app is resumed
+      // from the background after a deep link). Otherwise a stale suggested QSO
+      // reappears as a duplicate of the previously logged contact.
+      navigation.setParams({ qso: undefined })
     }
     if (route?.params?.selectedUUID && lastSelectedUUID !== route?.params?.selectedUUID) {
       setLastSelectedUUID(route?.params?.selectedUUID)
       dispatch(manageNextQSO({ selectedUUID: route?.params?.selectedUUID, qsos, operation, settings }))
     }
-  }, [route?.params?.qso, route?.params?.selectedUUID, lastSuggestedQSO, lastSelectedUUID, dispatch, operation, settings, qsos])
+  }, [route?.params?.qso, route?.params?.selectedUUID, lastSuggestedQSO, lastSelectedUUID, dispatch, navigation, operation, settings, qsos])
 
   useEffect(() => { // Ensure the clock is ticking
     dispatch(startTickTock())

--- a/src/store/operations/actions/findOrCreateOperation.js
+++ b/src/store/operations/actions/findOrCreateOperation.js
@@ -1,0 +1,58 @@
+// Copyright ©️ 2026 Jeff Kowalski <jeff.kowalski@gmail.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { activationTypeForKey } from '../../../tools/deepLinkTools'
+import { selectAllOperations } from '../operationsSlice'
+import { addNewOperation } from './operationsDB'
+import { mergeDataIntoOperation } from './setOperationData'
+
+export const RECENT_WINDOW_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+/**
+ * Find a recent operation activating exactly `ourRefs` (as `[{ type, ref }]`
+ * activity-key pairs), or create one.
+ *
+ * Matching is an exact set comparison: an operation is reused only when its
+ * activation references are precisely the requested set, no more, no less.
+ * A park-only request must not latch onto a park+summit operation (those are
+ * distinct activations), and a park+summit request must not reuse a park-only
+ * operation.
+ */
+export const findOrCreateOperation = ({ ourRefs }) => async (dispatch, getState) => {
+  const operations = selectAllOperations(getState())
+  const cutoff = Date.now() - RECENT_WINDOW_MS
+  const wantedRefs = ourRefs.map(({ type, ref }) => ({ type: activationTypeForKey(type), ref }))
+
+  const existingOp = Object.values(operations || {}).find(op => {
+    if (!op || op.deleted) return false
+    const lastActive = op.startAtMillisMax || op.createdAtMillis || 0
+    if (lastActive < cutoff) return false
+    return sameRefSet(op.refs, wantedRefs)
+  })
+  if (existingOp) return existingOp
+
+  // Decorate the refs and derive title/grid BEFORE creating the operation, so
+  // it is stored complete in one write. Creating first and titling second
+  // leaves a window where the screen mounting on the new operation reads the
+  // untitled version back from the database and clobbers the title.
+  let attrs = { refs: wantedRefs }
+  try {
+    attrs = await dispatch(mergeDataIntoOperation({ operation: {}, data: { refs: wantedRefs } }))
+  } catch (e) {
+    // Decoration is best-effort; fall back to the undecorated refs.
+  }
+
+  return await dispatch(addNewOperation({ ...attrs, _isNew: true }))
+}
+
+/**
+ * True when an operation's references are exactly the same set as `wantedRefs`
+ * (same type:ref pairs, in any order).
+ */
+function sameRefSet (opRefs, wantedRefs) {
+  const present = (opRefs || []).filter(r => r?.type && r?.ref)
+  if (present.length !== wantedRefs.length) return false
+  const keyOf = r => `${r.type}:${r.ref}`
+  const opKeys = new Set(present.map(keyOf))
+  return wantedRefs.every(r => opKeys.has(keyOf(r)))
+}

--- a/src/store/operations/actions/findOrCreateOperation.spec.js
+++ b/src/store/operations/actions/findOrCreateOperation.spec.js
@@ -1,0 +1,102 @@
+// Copyright ©️ 2026 Jeff Kowalski <jeff.kowalski@gmail.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { findOrCreateOperation } from './findOrCreateOperation'
+
+// deepLinkTools imports this ESM package at module load; stub it out.
+jest.mock('@ham2k/lib-operation-data', () => ({ bandForFrequency: () => undefined }))
+
+jest.mock('../../../extensions/registry', () => ({
+  findHooks: (category, { key } = {}) => {
+    if (category !== 'activity') return []
+    const hooks = [
+      { key: 'sota', activationType: 'sotaActivation', huntingType: 'sota' },
+      { key: 'pota', activationType: 'potaActivation', huntingType: 'pota' }
+    ]
+    return key ? hooks.filter(h => h.key === key) : hooks
+  }
+}))
+
+// Stub the slice and sibling actions so this spec exercises only the
+// find-or-create logic, without pulling in the store or the database layer.
+jest.mock('../operationsSlice', () => ({
+  selectAllOperations: (state) => state.operations
+}))
+jest.mock('./operationsDB', () => ({
+  addNewOperation: (operation) => async () => ({ uuid: 'new-op-uuid', ...operation })
+}))
+// Pass the refs through as if decorated; title derivation is upstream's concern.
+jest.mock('./setOperationData', () => ({
+  mergeDataIntoOperation: ({ operation, data }) => async () => ({ ...operation, ...data })
+}))
+
+describe('findOrCreateOperation', () => {
+  const dispatch = jest.fn(async (action) => (typeof action === 'function' ? action(dispatch, () => ({})) : action))
+  beforeEach(() => dispatch.mockClear())
+
+  const run = ({ ourRefs, operations }) => findOrCreateOperation({ ourRefs })(dispatch, () => ({ operations }))
+
+  const ourRefs = [{ type: 'sota', ref: 'W6/CT-006' }]
+
+  it('reuses a recent operation activating a matching ref', async () => {
+    const recent = { uuid: 'op-1', createdAtMillis: Date.now(), refs: [{ type: 'sotaActivation', ref: 'W6/CT-006' }] }
+    const op = await run({ ourRefs, operations: { 'op-1': recent } })
+    expect(op.uuid).toBe('op-1')
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+
+  it('ignores stale operations (older than 24h) and creates a new one', async () => {
+    const stale = { uuid: 'op-old', createdAtMillis: Date.now() - 25 * 60 * 60 * 1000, refs: [{ type: 'sotaActivation', ref: 'W6/CT-006' }] }
+    const op = await run({ ourRefs, operations: { 'op-old': stale } })
+    expect(op.uuid).toBe('new-op-uuid')
+    expect(op.refs).toEqual([{ type: 'sotaActivation', ref: 'W6/CT-006' }])
+  })
+
+  it('creates a new activation operation when none match', async () => {
+    const op = await run({ ourRefs, operations: {} })
+    expect(op.uuid).toBe('new-op-uuid')
+    expect(op.refs).toEqual([{ type: 'sotaActivation', ref: 'W6/CT-006' }])
+  })
+
+  describe('our operation covering more than one reference (n-fer)', () => {
+    const multiRefs = [{ type: 'pota', ref: 'US-1234' }, { type: 'sota', ref: 'W6/CT-006' }]
+    const recentOp = (refs) => ({ uuid: 'op-multi', createdAtMillis: Date.now(), refs })
+
+    it('reuses an operation whose refs are exactly the requested set (any order)', async () => {
+      const recent = recentOp([
+        { type: 'sotaActivation', ref: 'W6/CT-006' },
+        { type: 'potaActivation', ref: 'US-1234' }
+      ])
+      const op = await run({ ourRefs: multiRefs, operations: { 'op-multi': recent } })
+      expect(op.uuid).toBe('op-multi')
+      expect(dispatch).not.toHaveBeenCalled()
+    })
+
+    it('creates a new operation carrying every our.ref as an activation', async () => {
+      const op = await run({ ourRefs: multiRefs, operations: {} })
+      expect(op.uuid).toBe('new-op-uuid')
+      expect(op.refs).toEqual([
+        { type: 'potaActivation', ref: 'US-1234' },
+        { type: 'sotaActivation', ref: 'W6/CT-006' }
+      ])
+    })
+
+    it('does NOT reuse an operation activating only some of the requested refs', async () => {
+      // op is a summit-only activation; the request is park + summit, different activation
+      const recent = recentOp([{ type: 'sotaActivation', ref: 'W6/CT-006' }])
+      const op = await run({ ourRefs: multiRefs, operations: { 'op-multi': recent } })
+      expect(op.uuid).toBe('new-op-uuid')
+    })
+
+    it('does NOT reuse a multi-ref operation for a single-ref request (a park without the summit)', async () => {
+      // activating just the park must not grab the park+summit n-fer operation
+      const recent = recentOp([
+        { type: 'potaActivation', ref: 'US-1234' },
+        { type: 'sotaActivation', ref: 'W6/CT-006' }
+      ])
+      const op = await run({ ourRefs: [{ type: 'pota', ref: 'US-1234' }], operations: { 'op-multi': recent } })
+      expect(op.uuid).toBe('new-op-uuid')
+      expect(op.refs).toEqual([{ type: 'potaActivation', ref: 'US-1234' }])
+    })
+  })
+})

--- a/src/store/operations/index.js
+++ b/src/store/operations/index.js
@@ -6,6 +6,7 @@ import reducer from './operationsSlice'
 export * from './operationsSlice'
 export * from './actions/operationsDB'
 export * from './actions/setOperationData'
+export * from './actions/findOrCreateOperation'
 export * from './actions/dataExchangeActions'
 export * from './actions/operationTemplates'
 

--- a/src/tools/deepLinkTools.js
+++ b/src/tools/deepLinkTools.js
@@ -1,0 +1,79 @@
+// Copyright ©️ 2026 Jeff Kowalski <jeff.kowalski@gmail.com>
+// SPDX-License-Identifier: MPL-2.0
+
+// Pure helpers for Ham2K deep links, kept apart from the headless component in
+// `DeepLinks.jsx` so they can be unit-tested without the React Native harness.
+
+import { bandForFrequency } from '@ham2k/lib-operation-data'
+
+import { findHooks } from '../extensions/registry'
+
+const DEBUG = false
+
+/**
+ * Build a suggested QSO from deep-link parameters: the station being worked
+ * (`their.call`), its hunted references (`their.refs`), and frequency/mode.
+ */
+export function buildSuggestedQSO (params, url) {
+  let freq
+  if (params.freq) {
+    freq = Number(params.freq)
+  } else if (params.frequency) {
+    freq = Number(params.frequency) / 1000
+  }
+  const band = freq ? bandForFrequency(freq) : params.band
+
+  const qso = {
+    uuid: 'suggested-qso',
+    their: {},
+    band,
+    freq,
+    mode: params.mode?.toUpperCase(),
+    startAtMillis: params.startAtMillis ? Number(params.startAtMillis) : undefined,
+    _suggestedKey: url
+  }
+
+  if (params['their.call']) qso.their.call = params['their.call'].toUpperCase()
+
+  // their.refs: hunted references, placed on the QSO, mapped from the
+  // activity key (e.g. `pota`) to its hunting type.
+  const theirRefs = parseRefs(params['their.refs'])
+  if (theirRefs?.length) {
+    qso.refs = theirRefs.map(({ type, ref }) => ({ type: huntingTypeForKey(type) ?? type, ref }))
+  }
+
+  return qso
+}
+
+export function activationTypeForKey (key) {
+  return findHooks('activity', { key })[0]?.activationType
+}
+
+export function huntingTypeForKey (key) {
+  return findHooks('activity', { key })[0]?.huntingType
+}
+
+/**
+ * Parse a comma-separated list of `type:ref` pairs into `[{ type, ref }]`.
+ * Types are matched against the activity registry; unknown types are skipped.
+ * Returns `undefined` when the string is empty or yields no valid pairs.
+ */
+export function parseRefs (refsString) {
+  if (!refsString) return undefined
+
+  const refs = []
+  refsString.split(',').map(r => r.trim()).filter(r => r).forEach(part => {
+    const colon = part.indexOf(':')
+    if (colon < 1) return
+    const type = part.slice(0, colon).toLowerCase()
+    const ref = part.slice(colon + 1)
+    if (!ref) return
+    if (!activationTypeForKey(type)) {
+      if (DEBUG) console.log('[DeepLink] skipping unknown ref type:', type)
+      return
+    }
+    refs.push({ type, ref })
+  })
+
+  return refs.length ? refs : undefined
+}

--- a/src/tools/deepLinkTools.spec.js
+++ b/src/tools/deepLinkTools.spec.js
@@ -1,0 +1,120 @@
+// Copyright ©️ 2026 Jeff Kowalski <jeff.kowalski@gmail.com>
+// SPDX-License-Identifier: MPL-2.0
+
+import { buildSuggestedQSO, parseRefs } from './deepLinkTools'
+
+jest.mock('../extensions/registry', () => ({
+  findHooks: (category, { key } = {}) => {
+    if (category !== 'activity') return []
+    const hooks = [
+      { key: 'sota', activationType: 'sotaActivation', huntingType: 'sota' },
+      { key: 'pota', activationType: 'potaActivation', huntingType: 'pota' },
+      { key: 'wwff', activationType: 'wwffActivation', huntingType: 'wwff' },
+      { key: 'gma', activationType: 'gmaActivation', huntingType: 'gma' },
+      { key: 'wca', activationType: 'wcaActivation', huntingType: 'wca' },
+      { key: 'zlota', activationType: 'zlotaActivation', huntingType: 'zlota' }
+    ]
+    return key ? hooks.filter(h => h.key === key) : hooks
+  }
+}))
+
+jest.mock('@ham2k/lib-operation-data', () => ({
+  bandForFrequency: (freq) => {
+    if (freq >= 14000 && freq < 14350) return '20m'
+    if (freq >= 7000 && freq < 7300) return '40m'
+    return undefined
+  },
+  modeForFrequency: (freq) => (freq < 14100 ? 'CW' : 'SSB')
+}))
+
+describe('buildSuggestedQSO', () => {
+  it('parses a QSO with their.refs and Hz frequency', () => {
+    const qso = buildSuggestedQSO(
+      { 'their.call': 'k6test', 'their.refs': 'sota:W6/CT-006', frequency: '14285000', mode: 'cw' },
+      'com.ham2k://qso'
+    )
+    expect(qso.their.call).toBe('K6TEST')
+    expect(qso.freq).toBe(14285)
+    expect(qso.band).toBe('20m')
+    expect(qso.mode).toBe('CW')
+    expect(qso.refs).toEqual([{ type: 'sota', ref: 'W6/CT-006' }])
+  })
+
+  it('accepts freq in kHz when frequency (Hz) is absent', () => {
+    const qso = buildSuggestedQSO({ freq: '7185', 'their.call': 'ki2d' }, 'url')
+    expect(qso.freq).toBe(7185)
+    expect(qso.band).toBe('40m')
+  })
+
+  it('leaves mode undefined when omitted (no crash)', () => {
+    const qso = buildSuggestedQSO({ 'their.call': 'ki2d' }, 'url')
+    expect(qso.mode).toBeUndefined()
+  })
+
+  it('skips unknown ref types (lenient)', () => {
+    const qso = buildSuggestedQSO({ 'their.refs': 'iota:NA-001,pota:US-1234' }, 'url')
+    expect(qso.refs).toEqual([{ type: 'pota', ref: 'US-1234' }])
+  })
+
+  it('uppercases their.call, preserving a portable suffix and a multi-op list', () => {
+    const qso = buildSuggestedQSO({ 'their.call': 'ki2d,s5/kc6x/p' }, 'url')
+    expect(qso.their.call).toBe('KI2D,S5/KC6X/P')
+  })
+
+  it('ignores our.call (not read; the operation supplies our station)', () => {
+    const qso = buildSuggestedQSO({ 'our.call': 'kc6x', 'their.call': 'ki2d' }, 'url')
+    expect(qso.our).toBeUndefined()
+  })
+
+  it('does not place our.refs on the QSO', () => {
+    const qso = buildSuggestedQSO({ 'our.refs': 'sota:W6/CT-006' }, 'url')
+    expect(qso.refs).toBeUndefined()
+  })
+
+  describe('multiple references (n-fer activations)', () => {
+    it('maps multiple their.refs across programs (park + summit) onto the QSO', () => {
+      const qso = buildSuggestedQSO({ 'their.refs': 'pota:US-1234,sota:W6/CT-006' }, 'url')
+      expect(qso.refs).toEqual([
+        { type: 'pota', ref: 'US-1234' },
+        { type: 'sota', ref: 'W6/CT-006' }
+      ])
+    })
+
+    it('keeps several parks of the same program for an n-fer chase', () => {
+      const qso = buildSuggestedQSO({ 'their.refs': 'pota:US-1234,pota:US-5678' }, 'url')
+      expect(qso.refs).toEqual([
+        { type: 'pota', ref: 'US-1234' },
+        { type: 'pota', ref: 'US-5678' }
+      ])
+    })
+
+    it('keeps only the valid refs when an n-fer list mixes known and unknown types', () => {
+      const qso = buildSuggestedQSO({ 'their.refs': 'pota:US-1234,iota:NA-001,sota:W6/CT-006' }, 'url')
+      expect(qso.refs).toEqual([
+        { type: 'pota', ref: 'US-1234' },
+        { type: 'sota', ref: 'W6/CT-006' }
+      ])
+    })
+  })
+})
+
+describe('parseRefs', () => {
+  it('parses a comma-separated type:ref list', () => {
+    expect(parseRefs('pota:US-1234,sota:W6/CT-006')).toEqual([
+      { type: 'pota', ref: 'US-1234' },
+      { type: 'sota', ref: 'W6/CT-006' }
+    ])
+  })
+
+  it('skips unknown types and malformed parts', () => {
+    expect(parseRefs('iota:NA-001,pota:US-1234,nonsense,:x,pota:')).toEqual([
+      { type: 'pota', ref: 'US-1234' }
+    ])
+  })
+
+  it('returns undefined for empty or all-invalid input', () => {
+    expect(parseRefs('')).toBeUndefined()
+    expect(parseRefs(undefined)).toBeUndefined()
+    expect(parseRefs('iota:NA-001')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
PoLo can be driven by companion apps (e.g. SOTAcat, SOTAmat) over deep links. Following up on review feedback, the single overloaded `/qso` route is now split by intent:

- **`/operation?our.refs=pota:US-1234,sota:W6%2FCT-006`** finds a recent operation activating exactly those references, or creates one, and opens it for logging. Matching is an exact set comparison with a 24-hour window: a park-only link doesn't latch onto a park+summit operation, and vice versa.
- **`/vfo?frequency=14250000&mode=SSB`** sets the logging frequency and mode (VFO) for contacts logged subsequently.
- **`/qso?their.call=...&their.refs=...&frequency=...&mode=...`** presents a QSO for logging in the current (or most recent) operation, as before. (It no longer reads `our.refs`.)

Also in this change:

- Pure parsing helpers moved out of the src root into `src/tools/deepLinkTools.js`. Operation lookup lives in `src/store/operations/actions/findOrCreateOperation.js`. Both have unit tests, plus regression tests for the logging flow (VFO carry-forward, interrupted-entry preservation).
- Operations created by `/operation` are decorated and titled in a single write. (Creating first and titling second left a cold-start window where the operation screen read the untitled row back from the database and the home list showed "General Operation".)
- An unstarted blank QSO is no longer queued and restored across a deep link; only an entry the operator actually began is preserved.

Tested on device on Android (standalone release-style build): operation setup and reuse, VFO updates including explicit mode, chase prefill with hunted refs, freq/mode carry-forward after logging, and interrupted-entry restore. SOTAcat's emitter has been updated to match and tested end-to-end against this build, including in-field use during a SOTA activation. iOS has not been exercised; the routing changes are platform-neutral JS, but a check on the simulator would be welcome.
