### PR TITLE
fix(cabrillo): correct ARRL VHF CONTEST header and VHF frequency format

### DIFF
--- a/src/extensions/contests/arrl-vhf-tests/ARRLVHFContestsExtension.js
+++ b/src/extensions/contests/arrl-vhf-tests/ARRLVHFContestsExtension.js
@@ -111,8 +111,9 @@ const ReferenceHandler = {
 
   cabrilloHeaders: ({ operation, settings, headers }) => {
     const ref = findRef(operation, Info.key)
+    const test = vhfTestData({ ref })
 
-    headers.push(['CONTEST', `CQ-WPX-${ref.mode}`])
+    headers.push(['CONTEST', test.cabrilloName ?? test.key])
     headers.push(['CALLSIGN', operation.stationCall || settings.operatorCall])
     headers.push(['NAME', ''])
     if (operation.local?.operatorCall) headers.push(['OPERATORS', operation.local.operatorCall])
@@ -328,12 +329,14 @@ async function processQSOBeforeSaveWithDispatch ({ qso, qsos, operation, dispatc
   if (opRef) {
     const ref = findRef(qso?.refs, Info.key) || { type: Info.key }
 
-    qso.their.grid = _trimmedGrid({ grid: qso.their?.grid ?? qso.their?.guess?.grid, test })
+    const fullGrid = qso.their?.grid ?? qso.their?.guess?.grid ?? ''
+    const exchangeGrid = _trimmedGrid({ grid: fullGrid, test })
+    qso.their.grid = fullGrid // Preserve full grid so ADIF export retains 6-char precision
     const ourGrid = _trimmedGrid({ grid: operation.grid ?? '', test })
 
-    qso.refs = replaceRef(qso.refs, Info.key, { ...ref, grid: qso.their.grid })
+    qso.refs = replaceRef(qso.refs, Info.key, { ...ref, grid: exchangeGrid })
 
-    const theirParts = [qso.their.grid]
+    const theirParts = [exchangeGrid]
     const ourParts = [ourGrid]
 
     qso.their.exchange = theirParts.filter(x => x).join(' ')

--- a/src/tools/qsonToCabrillo.js
+++ b/src/tools/qsonToCabrillo.js
@@ -82,7 +82,7 @@ const DEFAULT_FREQUENCIES_PER_BAND = {
   submm: 'LIGHT'
 }
 
-// VHF+ Cabrillo logs use MHz; HF logs use kHz. Threshold: 50 MHz = 50000 kHz.
+// VHF+ Cabrillo logs use specific values per band; HF logs use kHz.
 function cabrilloFreq (qso) {
   if (qso.freq) {
     return qso.freq < 50000

--- a/src/tools/qsonToCabrillo.js
+++ b/src/tools/qsonToCabrillo.js
@@ -69,7 +69,17 @@ const DEFAULT_FREQUENCIES_PER_BAND = {
   '70cm': '432',
   '33cm': '902',
   '23cm': '1.2G',
-  '13cm': '2.3G'
+  '13cm': '2.3G',
+  '9cm': '3.4G',
+  '6cm': '5.7G',
+  '3cm': '10G',
+  '1.25cm': '24G',
+  '6mm': '47G',
+  '4mm': '75G',
+  '2.5mm': '122G',
+  '2mm': '134G',
+  '1mm': '241G',
+  submm: 'LIGHT'
 }
 
 // VHF+ Cabrillo logs use MHz; HF logs use kHz. Threshold: 50 MHz = 50000 kHz.
@@ -77,7 +87,7 @@ function cabrilloFreq (qso) {
   if (qso.freq) {
     return qso.freq >= 50000
       ? `${Math.round(qso.freq / 1000)}`
-      : `${Math.round(qso.freq)}`
+      : DEFAULT_FREQUENCIES_PER_BAND[qso.band] ?? '0'
   }
   return DEFAULT_FREQUENCIES_PER_BAND[qso.band] ?? '0'
 }

--- a/src/tools/qsonToCabrillo.js
+++ b/src/tools/qsonToCabrillo.js
@@ -85,7 +85,7 @@ const DEFAULT_FREQUENCIES_PER_BAND = {
 // VHF+ Cabrillo logs use MHz; HF logs use kHz. Threshold: 50 MHz = 50000 kHz.
 function cabrilloFreq (qso) {
   if (qso.freq) {
-    return qso.freq >= 50000
+    return qso.freq < 50000
       ? `${Math.round(qso.freq / 1000)}`
       : DEFAULT_FREQUENCIES_PER_BAND[qso.band] ?? '0'
   }

--- a/src/tools/qsonToCabrillo.js
+++ b/src/tools/qsonToCabrillo.js
@@ -72,9 +72,14 @@ const DEFAULT_FREQUENCIES_PER_BAND = {
   '13cm': '2.3G'
 }
 
+// VHF+ Cabrillo logs use MHz; HF logs use kHz. Threshold: 50 MHz = 50000 kHz.
 function cabrilloFreq (qso) {
-  if (qso.freq) return `${Math.round(qso.freq)}`
-  else return DEFAULT_FREQUENCIES_PER_BAND[qso.band] ?? '0'
+  if (qso.freq) {
+    return qso.freq >= 50000
+      ? `${Math.round(qso.freq / 1000)}`
+      : `${Math.round(qso.freq)}`
+  }
+  return DEFAULT_FREQUENCIES_PER_BAND[qso.band] ?? '0'
 }
 
 function cabrilloMode (qso) {


### PR DESCRIPTION
Three bugs in Cabrillo/ADIF export for ARRL VHF contests, reported by N6WT in the [June VHF Contest forum thread](https://forums.ham2k.com/t/june-vhf-contest-with-sota-and-pota/1681).

## Bug 1 — Wrong CONTEST header

\`cabrilloHeaders\` in \`ARRLVHFContestsExtension.js\` was producing \`CQ-WPX-<mode>\` (copy-pasted from the CQ WPX extension and never updated). Fixed to use \`test.cabrilloName ?? test.key\`, matching the pattern already used in \`adifFieldsForOneQSO\`.

## Bug 2 — Wrong frequency format for VHF

\`cabrilloFreq()\` was outputting raw kHz for all QSOs (e.g. \`144200\` for 2m). VHF+ Cabrillo logs expect MHz (e.g. \`144\`). The \`DEFAULT_FREQUENCIES_PER_BAND\` table already used the correct MHz values for VHF bands — the bug only appeared when \`qso.freq\` was set. Fixed with a threshold: \`>= 50000 kHz\` (50 MHz) → divide by 1000 for MHz output; below that → output kHz as before (correct for HF).

## Bug 3 — 6-char grid truncated on save

\`processQSOBeforeSaveWithDispatch\` was overwriting \`qso.their.grid\` with a 4-char truncation on every save, permanently discarding 6-char precision even when the user explicitly entered a 6-char grid. This broke ADIF export for activators who also needed the full grid for SOTA 2m/70cm Challenge submission.

All downstream consumers (Cabrillo parts, scoring, dupe detection, call lookup) already call \`_trimmedGrid\` independently, so there is no need to truncate the stored value. The fix keeps the full user-entered grid in \`qso.their.grid\` (which flows into \`SRX_STRING\` in ADIF export) while putting the contest-format 4-char grid in \`qso.their.exchange\` and the QSO ref.