### PR TITLE
fix: remove stray space at the end of User-Agent in some spots

### DIFF
--- a/src/store/dataFiles/actions/dataFileFS.js
+++ b/src/store/dataFiles/actions/dataFileFS.js
@@ -206,7 +206,7 @@ export async function fetchAndProcessURL ({ url, key, process, definition, info,
   url = await resolveDownloadUrl(url)
 
   const headers = {
-    'User-Agent': `Ham2K Portable Logger / ${packageJson.version} `
+    'User-Agent': `Ham2K Portable Logger / ${packageJson.version}`
   }
   if (DEBUG_FETCH) console.log('Fetching', { url, info })
   if (info?.data?.etag) {
@@ -232,7 +232,7 @@ export async function fetchAndProcessBatchedLines ({ url, key, processLineBatch,
   }
 
   const headers = {
-    'User-Agent': `Ham2K Portable Logger / ${packageJson.version} `
+    'User-Agent': `Ham2K Portable Logger / ${packageJson.version}`
   }
   if (DEBUG_FETCH) console.log('Fetching for batching', { url, info })
   if (info?.data?.etag) {


### PR DESCRIPTION
It looks like some servers don't like a trailing space there

<img width="1328" height="691" alt="ham2k-trailing-space" src="https://github.com/user-attachments/assets/e7fd1518-14a5-410c-b95a-55fc3052d8b0" />

73